### PR TITLE
Refactor aperture routing modules + improve model bootstrap and headers

### DIFF
--- a/.changeset/serious-otters-sort.md
+++ b/.changeset/serious-otters-sort.md
@@ -1,0 +1,23 @@
+---
+"@aliou/pi-ts-aperture": minor
+---
+
+Refactor the Aperture routing implementation into focused modules and improve startup model discovery.
+
+### What changed
+
+- Split the previous large `src/index.ts` into a clearer architecture:
+  - `src/providers/aperture.ts` for routing/bootstrap/model refresh logic
+  - `src/providers/model-config.ts` for model synthesis/merge helpers
+  - `src/lib/aperture-api.ts` for Aperture API discovery calls
+  - `src/state/provider-model-cache.ts` for in-memory model cache state
+- Keep `src/index.ts` as orchestration only (load config, register hooks/commands).
+- Preserve and explicitly inject provenance headers when routing through Aperture:
+  - `Referer: https://pi.dev`
+  - `X-Title: npm:@aliou/pi-ts-aperture`
+- Fix active model refresh timing by awaiting model re-resolution before request execution.
+- Improve OpenRouter CLI model selection reliability by bootstrapping discovered models from Aperture when needed.
+
+### Why minor
+
+This release introduces observable behavior improvements (model availability/routing reliability and header behavior) in addition to internal refactoring.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,124 +1,76 @@
 /**
  * Pi extension for Tailscale Aperture integration.
  *
- * Routes selected LLM providers through an Aperture gateway on your tailnet.
- * Aperture handles API key injection and request routing, so this extension
- * overrides each provider's baseUrl and sets a dummy apiKey.
+ * Keeps the entry point focused on orchestration:
+ * - load config
+ * - bootstrap provider/model visibility
+ * - register lifecycle hooks
+ * - register user commands
  */
 
 import type {
   ExtensionAPI,
   ExtensionContext,
 } from "@mariozechner/pi-coding-agent";
-import { VERSION } from "@mariozechner/pi-coding-agent";
 import { registerApertureSettings } from "./commands/settings";
 import { registerSetupCommand } from "./commands/setup";
 import { configLoader } from "./config";
+import {
+  applyAperture,
+  bootstrapProvidersFromAperture,
+  refreshActiveModel,
+  resetApertureModelsCache,
+} from "./providers/aperture";
 
-/**
- * Compute the full Aperture base URL from config, or null if not configured.
- */
-function resolveBaseUrl(): string | null {
-  const { baseUrl, providers } = configLoader.getConfig();
-  if (!baseUrl || providers.length === 0) return null;
-  return `${baseUrl.replace(/\/+$/, "")}/v1`;
+function registerApertureLifecycleHook(pi: ExtensionAPI): void {
+  pi.on("before_agent_start", async (_event, ctx) => {
+    if (!ctx?.modelRegistry) return;
+
+    const overriddenProviders = await applyAperture(pi, ctx.modelRegistry);
+    if (!ctx.model || !overriddenProviders.includes(ctx.model.provider)) return;
+
+    await refreshActiveModel(pi, ctx);
+  });
 }
 
-/**
- * Override provider registrations to route through Aperture.
- * Preserves existing models so extensions that registered custom models
- * before this runs don't lose them.
- */
-function overrideProviders(
+function createConfigChangeHandler(
   pi: ExtensionAPI,
-  registry: ExtensionContext["modelRegistry"],
-  providers: string[],
-  baseUrl: string,
-): void {
-  for (const provider of providers) {
-    const models = registry.getAll().filter((m) => m.provider === provider);
+): (ctx: ExtensionContext) => void {
+  let lastRegisteredProviders = [...configLoader.getConfig().providers];
 
-    pi.registerProvider(provider, {
-      baseUrl,
-      apiKey: "-",
-      ...(models.length > 0 && { api: models[0].api, models }),
-    });
-  }
-}
+  return (ctx: ExtensionContext) => {
+    const { providers } = configLoader.getConfig();
+    const removedProviders = lastRegisteredProviders.filter(
+      (provider) => !providers.includes(provider),
+    );
 
-/**
- * Apply Aperture configuration to the model registry.
- * Returns the list of providers that were overridden, or empty if no-op.
- */
-function applyAperture(
-  pi: ExtensionAPI,
-  registry: ExtensionContext["modelRegistry"],
-): string[] {
-  const url = resolveBaseUrl();
-  if (!url) return [];
+    resetApertureModelsCache();
+    void applyAperture(pi, ctx.modelRegistry);
+    lastRegisteredProviders = [...providers];
 
-  const { providers } = configLoader.getConfig();
-  overrideProviders(pi, registry, providers, url);
-  return providers;
-}
+    if (ctx.model && providers.includes(ctx.model.provider)) {
+      void refreshActiveModel(pi, ctx).then((updated) => {
+        if (!updated) return;
+        ctx.ui.notify(
+          `[aperture] re-routing ${ctx.model?.id ?? "model"} through ${ctx.model?.baseUrl ?? "aperture"}`,
+          "info",
+        );
+      });
+    }
 
-/**
- * Re-resolve the active model from the registry and update it via pi.setModel().
- * Call this after updating the registry to ensure the active model uses the new configuration.
- * Returns true if the model was updated.
- */
-function refreshActiveModel(pi: ExtensionAPI, ctx: ExtensionContext): boolean {
-  if (!ctx.model) return false;
-
-  const updated = ctx.modelRegistry.find(ctx.model.provider, ctx.model.id);
-  if (!updated) return false;
-
-  pi.setModel(updated);
-  return true;
+    for (const provider of removedProviders) {
+      pi.unregisterProvider(provider);
+    }
+  };
 }
 
 export default async function (pi: ExtensionAPI): Promise<void> {
   await configLoader.load();
+  await bootstrapProvidersFromAperture(pi);
 
-  let lastRegisteredProviders = [...configLoader.getConfig().providers];
+  registerApertureLifecycleHook(pi);
 
-  // Apply after all extensions have registered their providers and models.
-  pi.on("before_agent_start", async (_event, ctx) => {
-    if (!ctx?.modelRegistry) return;
-
-    const overriddenProviders = applyAperture(pi, ctx.modelRegistry);
-
-    // Re-resolve active model if it belongs to a reconfigured provider.
-    // The model was selected before before_agent_start fired, so we need to update it.
-    if (ctx.model && overriddenProviders.includes(ctx.model.provider)) {
-      refreshActiveModel(pi, ctx);
-    }
-  });
-
-  const onSetupComplete = (ctx: ExtensionContext) => {
-    const { providers } = configLoader.getConfig();
-    const removed = lastRegisteredProviders.filter(
-      (p) => !providers.includes(p),
-    );
-
-    applyAperture(pi, ctx.modelRegistry);
-    lastRegisteredProviders = [...providers];
-
-    // Re-resolve active model if it belongs to a reconfigured provider.
-    if (ctx.model && providers.includes(ctx.model.provider)) {
-      if (refreshActiveModel(pi, ctx)) {
-        ctx.ui.notify(
-          `[aperture] re-routing ${ctx.model.id} through ${ctx.model.baseUrl}`,
-          "info",
-        );
-      }
-    }
-
-    for (const p of removed) {
-      pi.unregisterProvider(p);
-    }
-  };
-
-  registerSetupCommand(pi, onSetupComplete);
-  registerApertureSettings(pi, onSetupComplete);
+  const onConfigChange = createConfigChangeHandler(pi);
+  registerSetupCommand(pi, onConfigChange);
+  registerApertureSettings(pi, onConfigChange);
 }

--- a/src/lib/aperture-api.ts
+++ b/src/lib/aperture-api.ts
@@ -1,0 +1,32 @@
+export interface ApertureProviderInfo {
+  id?: string;
+  models?: string[];
+}
+
+/**
+ * Fetch provider -> model list mapping from Aperture and keep only selected
+ * providers configured by the user.
+ */
+export async function fetchApertureProviderModels(
+  gatewayUrl: string,
+  providers: string[],
+): Promise<Map<string, string[]>> {
+  const response = await fetch(`${gatewayUrl}/api/providers`, {
+    signal: AbortSignal.timeout(4000),
+  });
+
+  if (!response.ok) {
+    return new Map();
+  }
+
+  const data = (await response.json()) as ApertureProviderInfo[];
+  const selectedProviders = new Set(providers);
+  const modelsByProvider = new Map<string, string[]>();
+
+  for (const provider of data) {
+    if (!provider.id || !selectedProviders.has(provider.id)) continue;
+    modelsByProvider.set(provider.id, provider.models ?? []);
+  }
+
+  return modelsByProvider;
+}

--- a/src/providers/aperture.ts
+++ b/src/providers/aperture.ts
@@ -1,0 +1,167 @@
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+  ProviderModelConfig,
+} from "@mariozechner/pi-coding-agent";
+import { configLoader } from "../config";
+import { fetchApertureProviderModels } from "../lib/aperture-api";
+import {
+  clearProviderModelsCache,
+  getProviderModelsCache,
+  setProviderModelsCache,
+} from "../state/provider-model-cache";
+import { mergeModels, toModelConfig } from "./model-config";
+
+/**
+ * Preserve provenance similarly to pi-synthetic so downstream providers can
+ * attribute traffic to Pi / this extension.
+ */
+const APERTURE_PROVENANCE_HEADERS = {
+  Referer: "https://pi.dev",
+  "X-Title": "npm:@aliou/pi-ts-aperture",
+};
+
+/**
+ * Providers for which we bootstrap models at startup (before first turn)
+ * to make CLI model selection deterministic.
+ */
+const BOOTSTRAP_DISCOVERY_PROVIDERS = new Set(["openrouter"]);
+
+/** Returns configured gateway URL without trailing slash. */
+export function resolveGatewayUrl(): string | null {
+  const { baseUrl, providers } = configLoader.getConfig();
+  if (!baseUrl || providers.length === 0) return null;
+  return baseUrl.replace(/\/+$/, "");
+}
+
+/**
+ * Returns the Aperture provider base URL used for provider registration.
+ *
+ * Aperture exposes multiple protocol paths (OpenAI, Anthropic, Gemini, ...).
+ * For this extension we route through the OpenAI-compatible `/v1` surface that
+ * Pi providers use (`openai-completions` API).
+ */
+export function resolveApertureProviderBaseUrl(): string | null {
+  const gateway = resolveGatewayUrl();
+  if (!gateway) return null;
+  return `${gateway}/v1`;
+}
+
+function resolveProviderHeaders(
+  models: ProviderModelConfig[],
+): Record<string, string> {
+  const modelHeaders = models.find((m) => m.headers)?.headers ?? {};
+  return {
+    ...APERTURE_PROVENANCE_HEADERS,
+    ...modelHeaders,
+  };
+}
+
+async function getOrLoadProviderModelsCache(
+  gatewayUrl: string,
+  providers: string[],
+): Promise<Map<string, string[]>> {
+  const current = getProviderModelsCache();
+  if (current) return current;
+
+  const loaded = await fetchApertureProviderModels(gatewayUrl, providers);
+  setProviderModelsCache(loaded);
+  return loaded;
+}
+
+export function resetApertureModelsCache(): void {
+  clearProviderModelsCache();
+}
+
+/**
+ * Apply Aperture override to configured providers:
+ * - provider baseUrl -> aperture /v1 endpoint
+ * - apiKey -> dummy token (Aperture injects real key server-side)
+ * - headers -> provenance + provider/model headers
+ */
+export async function applyAperture(
+  pi: ExtensionAPI,
+  registry: ExtensionContext["modelRegistry"],
+): Promise<string[]> {
+  const baseUrl = resolveApertureProviderBaseUrl();
+  const gatewayUrl = resolveGatewayUrl();
+  if (!baseUrl || !gatewayUrl) return [];
+
+  const { providers } = configLoader.getConfig();
+
+  let modelCache: Map<string, string[]>;
+  try {
+    modelCache = await getOrLoadProviderModelsCache(gatewayUrl, providers);
+  } catch {
+    modelCache = new Map();
+  }
+
+  for (const provider of providers) {
+    const existingModels = registry
+      .getAll()
+      .filter((m) => m.provider === provider) as ProviderModelConfig[];
+
+    const models = mergeModels(existingModels, modelCache.get(provider));
+
+    pi.registerProvider(provider, {
+      baseUrl,
+      apiKey: "-",
+      headers: resolveProviderHeaders(models),
+      ...(models.length > 0 && { api: models[0].api, models }),
+    });
+  }
+
+  return providers;
+}
+
+/**
+ * Pre-register selected providers from Aperture model discovery so CLI model
+ * resolution works even when a model is not present in Pi built-ins.
+ */
+export async function bootstrapProvidersFromAperture(
+  pi: ExtensionAPI,
+): Promise<void> {
+  const baseUrl = resolveApertureProviderBaseUrl();
+  const gatewayUrl = resolveGatewayUrl();
+  if (!baseUrl || !gatewayUrl) return;
+
+  const { providers } = configLoader.getConfig();
+
+  let modelCache: Map<string, string[]>;
+  try {
+    modelCache = await fetchApertureProviderModels(gatewayUrl, providers);
+    setProviderModelsCache(modelCache);
+  } catch {
+    return;
+  }
+
+  for (const provider of providers) {
+    if (!BOOTSTRAP_DISCOVERY_PROVIDERS.has(provider)) continue;
+
+    const modelIds = modelCache.get(provider) ?? [];
+    if (modelIds.length === 0) continue;
+
+    const models = modelIds.map((id) => toModelConfig(id));
+
+    pi.registerProvider(provider, {
+      baseUrl,
+      apiKey: "-",
+      api: "openai-completions",
+      headers: resolveProviderHeaders(models),
+      models,
+    });
+  }
+}
+
+/** Re-resolve and set current model after provider registry updates. */
+export async function refreshActiveModel(
+  pi: ExtensionAPI,
+  ctx: ExtensionContext,
+): Promise<boolean> {
+  if (!ctx.model) return false;
+
+  const updated = ctx.modelRegistry.find(ctx.model.provider, ctx.model.id);
+  if (!updated) return false;
+
+  return pi.setModel(updated);
+}

--- a/src/providers/model-config.ts
+++ b/src/providers/model-config.ts
@@ -1,0 +1,54 @@
+import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
+
+const DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
+/**
+ * Build a ProviderModelConfig for Aperture-discovered model IDs.
+ *
+ * When a template model is available (same provider), preserve its API/compat
+ * shape so behavior stays consistent after rerouting.
+ */
+export function toModelConfig(
+  id: string,
+  template?: ProviderModelConfig,
+): ProviderModelConfig {
+  return {
+    id,
+    name: template?.name ?? id,
+    api: template?.api ?? "openai-completions",
+    reasoning: template?.reasoning ?? false,
+    input: template?.input ?? ["text"],
+    cost: template?.cost ?? DEFAULT_COST,
+    contextWindow: template?.contextWindow ?? 128000,
+    maxTokens: template?.maxTokens ?? 16384,
+    headers: template?.headers,
+    compat: template?.compat,
+  };
+}
+
+/**
+ * Merge known provider models with Aperture-discovered model IDs.
+ * Existing models win; missing IDs are synthesized from template defaults.
+ */
+export function mergeModels(
+  existingModels: ProviderModelConfig[],
+  apertureModelIds: string[] | undefined,
+): ProviderModelConfig[] {
+  if (!apertureModelIds || apertureModelIds.length === 0) return existingModels;
+
+  const modelsById = new Map(existingModels.map((m) => [m.id, m]));
+  const template = existingModels[0];
+
+  for (const modelId of apertureModelIds) {
+    if (!modelsById.has(modelId)) {
+      modelsById.set(modelId, toModelConfig(modelId, template));
+    }
+  }
+
+  return [...modelsById.values()];
+}

--- a/src/state/provider-model-cache.ts
+++ b/src/state/provider-model-cache.ts
@@ -1,0 +1,18 @@
+/**
+ * In-memory cache for Aperture provider model discovery.
+ *
+ * Ephemeral by design: reset on config changes and process restart.
+ */
+let providerModelsCache: Map<string, string[]> | null = null;
+
+export function getProviderModelsCache(): Map<string, string[]> | null {
+  return providerModelsCache;
+}
+
+export function setProviderModelsCache(models: Map<string, string[]>): void {
+  providerModelsCache = models;
+}
+
+export function clearProviderModelsCache(): void {
+  providerModelsCache = null;
+}


### PR DESCRIPTION
## Summary

This PR refactors pi-ts-aperture to make the routing implementation clearer and easier to maintain, while preserving behavior and fixing routing reliability issues discovered during debugging.

## Changes

- Split previous large src/index.ts into focused modules:
  - src/providers/aperture.ts
  - src/providers/model-config.ts
  - src/lib/aperture-api.ts
  - src/state/provider-model-cache.ts
- Keep src/index.ts as orchestration only (load config, bootstrap, hook/command wiring).
- Add explicit Aperture provenance headers on routed providers:
  - Referer: https://pi.dev
  - X-Title: npm:@aliou/pi-ts-aperture
- Await active model refresh before request execution to avoid race conditions.
- Bootstrap discovery models for OpenRouter so CLI model selection works for Aperture-exposed IDs (for example: google/gemini-3.1-flash-image-preview).
- Rename helper to provider-agnostic wording:
  - resolveOpenAiBaseUrl -> resolveApertureProviderBaseUrl

## Validation

- pnpm typecheck passes
- Verified end-to-end routing in isolated setup through Aperture for:
  - synthetic / hf:moonshotai/Kimi-K2.5
  - openrouter / google/gemini-3.1-flash-image-preview
  - openrouter / moonshotai/kimi-k2.5
- Confirmed sessions appear in Aperture session API

## Release

- Added manual changeset for a minor bump:
  - .changeset/serious-otters-sort.md
