### PR TITLE
refactor: extract pure core functions

### DIFF
--- a/.changeset/colocate-tests.md
+++ b/.changeset/colocate-tests.md
@@ -1,0 +1,8 @@
+---
+"@aliou/pi-ts-aperture": patch
+---
+
+Co-locate unit tests with source files.
+
+Moves core unit tests from tests/core/ to src/core/*.test.ts.
+

--- a/.changeset/core-extract.md
+++ b/.changeset/core-extract.md
@@ -1,0 +1,12 @@
+---
+"@aliou/pi-ts-aperture": minor
+---
+
+Extract pure core functions from Pi glue.
+
+Move decision-making logic into pure functions in src/core/:
+- URL helpers: normalizeInputUrl, resolveGatewayUrl, resolveProviderBaseUrl
+- Plan builders: buildApplyPlan, planConfigChange
+
+All core logic is now unit-testable with no Pi dependencies.
+

--- a/.changeset/e2e-rpc.md
+++ b/.changeset/e2e-rpc.md
@@ -1,0 +1,8 @@
+---
+"@aliou/pi-ts-aperture": patch
+---
+
+Rewrite e2e tests to use RpcClient.
+
+Modernizes test infrastructure for better reliability.
+

--- a/.changeset/model-type.md
+++ b/.changeset/model-type.md
@@ -1,0 +1,8 @@
+---
+"@aliou/pi-ts-aperture": patch
+---
+
+Replace local ModelInfo type with Model<Api> from pi-ai.
+
+Uses Pi canonical model type instead of duplicating the shape.
+

--- a/.changeset/pi-update.md
+++ b/.changeset/pi-update.md
@@ -1,0 +1,6 @@
+---
+"@aliou/pi-ts-aperture": patch
+---
+
+Update Pi packages to 0.64.0.
+

--- a/.changeset/provider-model-check.md
+++ b/.changeset/provider-model-check.md
@@ -1,0 +1,8 @@
+---
+"@aliou/pi-ts-aperture": minor
+---
+
+Add per-provider gateway model checking.
+
+Validates which models are available on the gateway per configured provider.
+

--- a/.changeset/settings-model-check.md
+++ b/.changeset/settings-model-check.md
@@ -1,0 +1,8 @@
+---
+"@aliou/pi-ts-aperture": minor
+---
+
+Add gateway model checking to settings UI.
+
+Shows model availability status in the settings interface.
+

--- a/.changeset/setup-wizard.md
+++ b/.changeset/setup-wizard.md
@@ -1,0 +1,8 @@
+---
+"@aliou/pi-ts-aperture": minor
+---
+
+Rewrite setup wizard with Wizard + FuzzyMultiSelector.
+
+Improved UX for configuring Aperture with better multi-select support.
+

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "video": "https://assets.aliou.me/pi-extensions/demos/pi-ts-aperture.mp4"
   },
   "dependencies": {
-    "@aliou/pi-utils-settings": "^0.10.0"
+    "@aliou/pi-utils-settings": "^0.12.0"
   },
   "peerDependencies": {
-    "@mariozechner/pi-ai": "0.61.0",
-    "@mariozechner/pi-coding-agent": "0.61.0",
-    "@mariozechner/pi-tui": "0.61.0"
+    "@mariozechner/pi-ai": "0.64.0",
+    "@mariozechner/pi-coding-agent": "0.64.0",
+    "@mariozechner/pi-tui": "0.64.0"
   },
   "peerDependenciesMeta": {
     "@mariozechner/pi-coding-agent": {
@@ -56,14 +56,15 @@
     "changeset": "changeset",
     "version": "changeset version",
     "release": "pnpm changeset publish",
-    "test": "vitest run tests/e2e.test.ts",
-    "test:watch": "vitest watch tests/"
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:e2e": "vitest run tests/e2e.test.ts"
   },
   "devDependencies": {
     "@aliou/biome-plugins": "^0.3.2",
     "@biomejs/biome": "^2.3.13",
     "@changesets/cli": "^2.27.11",
-    "@mariozechner/pi-coding-agent": "0.61.0",
+    "@mariozechner/pi-coding-agent": "0.64.0",
     "@sinclair/typebox": "^0.34.48",
     "@types/node": "^25.0.10",
     "@vitest/coverage-v8": "^4.0.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,22 +5,22 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@mariozechner/pi-ai': 0.61.0
-  '@mariozechner/pi-tui': 0.61.0
+  '@mariozechner/pi-ai': 0.64.0
+  '@mariozechner/pi-tui': 0.64.0
 
 importers:
 
   .:
     dependencies:
       '@aliou/pi-utils-settings':
-        specifier: ^0.10.0
-        version: 0.10.0(@mariozechner/pi-coding-agent@0.61.0(ws@8.19.0)(zod@3.25.76))
+        specifier: ^0.12.0
+        version: 0.12.0(@mariozechner/pi-coding-agent@0.64.0(ws@8.19.0)(zod@3.25.76))
       '@mariozechner/pi-ai':
-        specifier: 0.61.0
-        version: 0.61.0(ws@8.19.0)(zod@3.25.76)
+        specifier: 0.64.0
+        version: 0.64.0(ws@8.19.0)(zod@3.25.76)
       '@mariozechner/pi-tui':
-        specifier: 0.61.0
-        version: 0.61.0
+        specifier: 0.64.0
+        version: 0.64.0
     devDependencies:
       '@aliou/biome-plugins':
         specifier: ^0.3.2
@@ -32,8 +32,8 @@ importers:
         specifier: ^2.27.11
         version: 2.29.8(@types/node@25.2.3)
       '@mariozechner/pi-coding-agent':
-        specifier: 0.61.0
-        version: 0.61.0(ws@8.19.0)(zod@3.25.76)
+        specifier: 0.64.0
+        version: 0.64.0(ws@8.19.0)(zod@3.25.76)
       '@sinclair/typebox':
         specifier: ^0.34.48
         version: 0.34.48
@@ -60,10 +60,10 @@ packages:
     peerDependencies:
       '@biomejs/biome': '>=2.0.0'
 
-  '@aliou/pi-utils-settings@0.10.0':
-    resolution: {integrity: sha512-sYCITYiv6H7LV6MJW+F5sGEqSavMFL+jLVZB/Z9H+UCsBzfb/2VAzef/GOBrbAD7zDC3jtQk123fILaPCD5tCA==}
+  '@aliou/pi-utils-settings@0.12.0':
+    resolution: {integrity: sha512-SacN6LLhhfJD9aA0lJGDqm5nuh3d16uYw9e5cybv7mHzrHFACre2s7cltkQTDDDGHOjEwNqYwdeTlGqtcSTVHA==}
     peerDependencies:
-      '@mariozechner/pi-coding-agent': '>=0.51.0'
+      '@mariozechner/pi-coding-agent': '>=0.61.0 <1'
     peerDependenciesMeta:
       '@mariozechner/pi-coding-agent':
         optional: true
@@ -627,22 +627,22 @@ packages:
     resolution: {integrity: sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==}
     hasBin: true
 
-  '@mariozechner/pi-agent-core@0.61.0':
-    resolution: {integrity: sha512-MBCZfcYDmc5ssZGitv66nSsjma0W+4VwnfzPDRXdOcIhtxiJYux2t8mZe23CbUb4WNkeY3eMU2N6pe4YWeGexg==}
+  '@mariozechner/pi-agent-core@0.64.0':
+    resolution: {integrity: sha512-IN/sIxWOD0v1OFVXHB605SGiZhO5XdEWG5dO8EAV08n3jz/p12o4OuYGvhGXmHhU28WXa/FGWC+FO5xiIih8Uw==}
     engines: {node: '>=20.0.0'}
 
-  '@mariozechner/pi-ai@0.61.0':
-    resolution: {integrity: sha512-iiTiZ91aEND1AfP314exsissbPJnMMZv0NWLkazFf8TwYlUo9qD+6TlXEUYnX1ZRMCnZ7RjSEVerRrQ63FGZXw==}
+  '@mariozechner/pi-ai@0.64.0':
+    resolution: {integrity: sha512-Z/Jnf+JSVDPLRcxJsa8XhYTJKIqKekNueaCpBLGQHgizL1F9RQ1Rur3rIfZpfXkt2cLu/AIPtOs223ueuoWaWg==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
-  '@mariozechner/pi-coding-agent@0.61.0':
-    resolution: {integrity: sha512-fN0DEdefqM4q7bztx5UKGtn8D6vg1sIsJRB4ljq11EKgO44Z4TQ3mmOlzKL5zCa3Wg5YeM3lf+cJoe1CAFL4zg==}
+  '@mariozechner/pi-coding-agent@0.64.0':
+    resolution: {integrity: sha512-Q4tcqSqFGQtOgCtRyIp1D80Nv2if13Q2pfbnrOlaT/mix90mLcZGML9jKVnT1jGSy5GMYudU1HsS7cx53kxb0g==}
     engines: {node: '>=20.6.0'}
     hasBin: true
 
-  '@mariozechner/pi-tui@0.61.0':
-    resolution: {integrity: sha512-gll0kAcBgSK7RFgsS1GrdlNglE2msh+fJS+1OXYUi3CVrWRUVGyCqEhbY9ogQ0qdrEkYT3o/6X1cnTj3yV6MuA==}
+  '@mariozechner/pi-tui@0.64.0':
+    resolution: {integrity: sha512-W1qLry9MAuN/V3YJmMv/BJa0VaYv721NkXPg/DGItdqWxuDc+1VdNbyAnRwxblNkIpXVUWL26x64BlyFXpxmkg==}
     engines: {node: '>=20.0.0'}
 
   '@mistralai/mistralai@1.14.1':
@@ -2164,9 +2164,9 @@ snapshots:
     dependencies:
       '@biomejs/biome': 2.4.2
 
-  '@aliou/pi-utils-settings@0.10.0(@mariozechner/pi-coding-agent@0.61.0(ws@8.19.0)(zod@3.25.76))':
+  '@aliou/pi-utils-settings@0.12.0(@mariozechner/pi-coding-agent@0.64.0(ws@8.19.0)(zod@3.25.76))':
     optionalDependencies:
-      '@mariozechner/pi-coding-agent': 0.61.0(ws@8.19.0)(zod@3.25.76)
+      '@mariozechner/pi-coding-agent': 0.64.0(ws@8.19.0)(zod@3.25.76)
 
   '@anthropic-ai/sdk@0.73.0(zod@3.25.76)':
     dependencies:
@@ -3033,9 +3033,9 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
-  '@mariozechner/pi-agent-core@0.61.0(ws@8.19.0)(zod@3.25.76)':
+  '@mariozechner/pi-agent-core@0.64.0(ws@8.19.0)(zod@3.25.76)':
     dependencies:
-      '@mariozechner/pi-ai': 0.61.0(ws@8.19.0)(zod@3.25.76)
+      '@mariozechner/pi-ai': 0.64.0(ws@8.19.0)(zod@3.25.76)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -3045,7 +3045,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.61.0(ws@8.19.0)(zod@3.25.76)':
+  '@mariozechner/pi-ai@0.64.0(ws@8.19.0)(zod@3.25.76)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@3.25.76)
       '@aws-sdk/client-bedrock-runtime': 3.991.0
@@ -3069,13 +3069,14 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.61.0(ws@8.19.0)(zod@3.25.76)':
+  '@mariozechner/pi-coding-agent@0.64.0(ws@8.19.0)(zod@3.25.76)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.61.0(ws@8.19.0)(zod@3.25.76)
-      '@mariozechner/pi-ai': 0.61.0(ws@8.19.0)(zod@3.25.76)
-      '@mariozechner/pi-tui': 0.61.0
+      '@mariozechner/pi-agent-core': 0.64.0(ws@8.19.0)(zod@3.25.76)
+      '@mariozechner/pi-ai': 0.64.0(ws@8.19.0)(zod@3.25.76)
+      '@mariozechner/pi-tui': 0.64.0
       '@silvia-odwyer/photon-node': 0.3.4
+      ajv: 8.18.0
       chalk: 5.6.2
       cli-highlight: 2.1.11
       diff: 8.0.3
@@ -3101,7 +3102,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-tui@0.61.0':
+  '@mariozechner/pi-tui@0.64.0':
     dependencies:
       '@types/mime-types': 2.1.4
       chalk: 5.6.2

--- a/src/commands/settings.ts
+++ b/src/commands/settings.ts
@@ -37,6 +37,9 @@ export function registerApertureSettings(
 
       const providers = tabConfig?.providers ?? resolved.providers;
 
+      const checkGatewayModels: string[] =
+        tabConfig?.checkGatewayModels ?? resolved.checkGatewayModels;
+
       return [
         {
           label: "Connection",
@@ -50,6 +53,39 @@ export function registerApertureSettings(
                 (tabConfig?.baseUrl ?? resolved.baseUrl) || "(not set)",
               values: undefined,
               submenu: undefined,
+            },
+            {
+              id: "checkGatewayModels",
+              label: "Gateway model checking",
+              description:
+                "Providers for which gateway model availability is checked",
+              currentValue:
+                checkGatewayModels.length > 0
+                  ? `${checkGatewayModels.length} provider(s)`
+                  : "disabled",
+              values: undefined,
+              submenu: (_val, submenuDone) => {
+                let latest = [...checkGatewayModels];
+                return new ArrayEditor({
+                  label: "Gateway-checked providers",
+                  items: [...checkGatewayModels],
+                  theme: settingsTheme,
+                  onSave: (items) => {
+                    latest = items;
+                    const updated = structuredClone(
+                      tabConfig ?? {},
+                    ) as ApertureConfig;
+                    setNestedValue(updated, "checkGatewayModels", items);
+                    setDraft(updated);
+                  },
+                  onDone: () =>
+                    submenuDone(
+                      latest.length > 0
+                        ? `${latest.length} provider(s)`
+                        : "disabled",
+                    ),
+                });
+              },
             },
           ],
         },

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -16,16 +16,8 @@ import { getSettingsListTheme } from "@mariozechner/pi-coding-agent";
 import type { Component, TUI } from "@mariozechner/pi-tui";
 import { Input, Key, matchesKey } from "@mariozechner/pi-tui";
 import { configLoader } from "../config";
+import { normalizeInputUrl } from "../core";
 import { checkApertureHealth } from "../lib/health";
-
-function normalizeUrl(url: string): string {
-  let result = url.trim();
-  if (!result) return result;
-  if (!result.startsWith("http://") && !result.startsWith("https://")) {
-    result = `http://${result}`;
-  }
-  return result.replace(/\/v1\/?$/, "").replace(/\/+$/, "");
-}
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
@@ -147,7 +139,7 @@ class UrlPrompt implements Component {
     this.input.onSubmit = () => {
       const value = this.input.getValue().trim();
       if (!value) return;
-      this.done(normalizeUrl(value));
+      this.done(normalizeInputUrl(value));
     };
     this.input.onEscape = () => {
       this.done(undefined);

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -2,244 +2,134 @@
  * aperture:setup -- interactive wizard for configuring Aperture.
  *
  * Steps:
- * 1. Ask for Aperture base URL (Input)
- * 2. Select providers to route through Aperture (FuzzySelector, multi-select loop)
- * 3. Save config and register providers
+ * 1. URL input (health check runs inline on Enter, auto-advances on success)
+ * 2. Provider selection with per-provider "verify models" sub-option
  */
 
-import { FuzzySelector } from "@aliou/pi-utils-settings";
+import {
+  FuzzyMultiSelector,
+  type FuzzyMultiSelectorItem,
+  getSettingsTheme,
+  type SettingsTheme,
+  Wizard,
+  type WizardStepContext,
+} from "@aliou/pi-utils-settings";
 import type {
   ExtensionAPI,
   ExtensionContext,
 } from "@mariozechner/pi-coding-agent";
-import { getSettingsListTheme } from "@mariozechner/pi-coding-agent";
 import type { Component, TUI } from "@mariozechner/pi-tui";
-import { Input, Key, matchesKey } from "@mariozechner/pi-tui";
+import { Input } from "@mariozechner/pi-tui";
 import { configLoader } from "../config";
 import { normalizeInputUrl } from "../core";
 import { checkApertureHealth } from "../lib/health";
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
-/**
- * Shows a spinner while verifying the Aperture URL is reachable.
- * Kicks off the health check on construction and resolves done(boolean)
- * when the check completes.
- */
-class HealthCheckSpinner implements Component {
-  private theme: ReturnType<typeof getSettingsListTheme>;
-  private url: string;
+// ---------------------------------------------------------------------------
+// Step 1: URL input with inline health check
+// ---------------------------------------------------------------------------
+
+class UrlStep implements Component {
+  private input: Input;
+  private theme: SettingsTheme;
   private tui: TUI;
-  // true = healthy, false = failed (retry), undefined = cancelled
-  private done: (result: boolean | undefined) => void;
+  private wizCtx: WizardStepContext;
+  private onUrl: (url: string) => void;
+  private readonly placeholder = "ai.pango-lin.ts.net";
+
+  private state: "idle" | "checking" | "ok" | "error" = "idle";
+  private errorMessage = "";
   private frame = 0;
-  private timer: ReturnType<typeof setInterval>;
-  private result: { ok: boolean; error?: string } | null = null;
+  private timer: ReturnType<typeof setInterval> | null = null;
 
   constructor(
-    theme: ReturnType<typeof getSettingsListTheme>,
-    url: string,
+    theme: SettingsTheme,
     tui: TUI,
-    done: (result: boolean | undefined) => void,
+    currentValue: string,
+    wizCtx: WizardStepContext,
+    onUrl: (url: string) => void,
   ) {
     this.theme = theme;
-    this.url = url;
     this.tui = tui;
-    this.done = done;
+    this.wizCtx = wizCtx;
+    this.onUrl = onUrl;
+    this.input = new Input();
+    if (currentValue) {
+      this.input.setValue(currentValue);
+    }
+    this.input.onSubmit = () => this.submit();
+  }
 
-    // Animate spinner at ~80ms per frame.
+  private submit(): void {
+    const value = this.input.getValue().trim();
+    if (!value || this.state === "checking") return;
+
+    const url = normalizeInputUrl(value);
+    this.state = "checking";
+    this.frame = 0;
+
     this.timer = setInterval(() => {
       this.frame = (this.frame + 1) % SPINNER_FRAMES.length;
       this.tui.requestRender();
     }, 80);
 
-    // Fire the check.
     checkApertureHealth(url).then((res) => {
-      clearInterval(this.timer);
-      this.result = res;
-      this.tui.requestRender();
+      if (this.timer) clearInterval(this.timer);
+      this.timer = null;
 
-      // On success, auto-advance after a brief pause.
-      // On failure, wait for user input (see handleInput).
       if (res.ok) {
-        setTimeout(() => this.done(true), 600);
+        this.state = "ok";
+        this.onUrl(url);
+        this.wizCtx.markComplete();
+        this.tui.requestRender();
+        setTimeout(() => this.wizCtx.goNext(), 400);
+      } else {
+        this.state = "error";
+        this.errorMessage = res.error ?? "unknown error";
+        this.tui.requestRender();
       }
     });
   }
 
-  render(_width: number): string[] {
-    const lines: string[] = [];
-    lines.push(this.theme.label(" Aperture Setup", true));
-    lines.push("");
-
-    if (!this.result) {
-      const spinner = SPINNER_FRAMES[this.frame];
-      lines.push(
-        this.theme.hint(`  ${spinner} Checking connection to ${this.url}...`),
-      );
-    } else if (this.result.ok) {
-      lines.push(this.theme.hint(`  Connected to ${this.url}`));
-    } else {
-      lines.push(
-        this.theme.hint(`  Could not reach ${this.url}: ${this.result.error}`),
-      );
-      lines.push("");
-      lines.push(
-        this.theme.hint(
-          "  Make sure the URL is correct and you are connected to the tailnet.",
-        ),
-      );
-      lines.push("");
-      lines.push(this.theme.hint("  Enter: try another URL · Esc: cancel"));
-    }
-
-    lines.push("");
-    return lines;
-  }
-
-  invalidate() {}
-
-  handleInput(data: string) {
-    // Only handle input after a failed check.
-    if (!this.result || this.result.ok) return;
-
-    if (matchesKey(data, Key.enter)) {
-      this.done(false); // retry
-    } else if (matchesKey(data, Key.escape)) {
-      this.done(undefined); // cancel wizard
-    }
-  }
-
-  dispose() {
-    clearInterval(this.timer);
-  }
-}
-
-/**
- * Simple input prompt component for the base URL step.
- */
-class UrlPrompt implements Component {
-  private input: Input;
-  private done: (value: string | undefined) => void;
-  private theme: ReturnType<typeof getSettingsListTheme>;
-  private placeholder = "ai.pango-lin.ts.net";
-
-  constructor(
-    theme: ReturnType<typeof getSettingsListTheme>,
-    currentValue: string,
-    done: (value: string | undefined) => void,
-  ) {
-    this.theme = theme;
-    this.done = done;
-    this.input = new Input();
-    if (currentValue) {
-      this.input.setValue(currentValue);
-    }
-
-    this.input.onSubmit = () => {
-      const value = this.input.getValue().trim();
-      if (!value) return;
-      this.done(normalizeInputUrl(value));
-    };
-    this.input.onEscape = () => {
-      this.done(undefined);
-    };
-  }
-
   render(width: number): string[] {
     const lines: string[] = [];
-    lines.push(this.theme.label(" Aperture Setup", true));
-    lines.push("");
+
     lines.push(
       this.theme.hint(`  Aperture base URL (e.g. ${this.placeholder}):`),
     );
     lines.push(`  ${this.input.render(width - 4).join("")}`);
     lines.push("");
-    lines.push(this.theme.hint("  Enter: confirm · Esc: cancel"));
+
+    if (this.state === "checking") {
+      const spinner = SPINNER_FRAMES[this.frame];
+      lines.push(this.theme.hint(`  ${spinner} Checking connection...`));
+    } else if (this.state === "ok") {
+      lines.push(this.theme.hint("  Connected."));
+    } else if (this.state === "error") {
+      lines.push(this.theme.hint(`  Could not connect: ${this.errorMessage}`));
+      lines.push(this.theme.hint("  Fix the URL and press Enter to retry."));
+    }
+
     return lines;
   }
 
-  invalidate() {}
+  invalidate(): void {}
 
-  handleInput(data: string) {
+  handleInput(data: string): void {
+    if (this.state === "checking") return;
+    this.state = "idle";
     this.input.handleInput(data);
   }
-}
 
-/**
- * Provider multi-select component. Uses FuzzySelector for search,
- * tracks selected providers, and lets the user confirm with Ctrl+S.
- */
-class ProviderMultiSelect implements Component {
-  private allProviders: string[];
-  private selected: Set<string>;
-  private theme: ReturnType<typeof getSettingsListTheme>;
-  private done: (value: string[] | undefined) => void;
-  private fuzzy: FuzzySelector;
-
-  constructor(
-    theme: ReturnType<typeof getSettingsListTheme>,
-    providers: string[],
-    preselected: string[],
-    done: (value: string[] | undefined) => void,
-  ) {
-    this.allProviders = providers;
-    this.selected = new Set(preselected);
-    this.theme = theme;
-    this.done = done;
-
-    this.fuzzy = new FuzzySelector({
-      label: "Select providers (Enter to toggle, Ctrl+S to confirm)",
-      items: this.allProviders,
-      theme,
-      onSelect: (value) => {
-        if (this.selected.has(value)) {
-          this.selected.delete(value);
-        } else {
-          this.selected.add(value);
-        }
-      },
-      onDone: () => {
-        this.done(undefined);
-      },
-    });
-  }
-
-  render(width: number): string[] {
-    const lines = this.fuzzy.render(width);
-
-    // Append selected providers summary
-    if (this.selected.size > 0) {
-      lines.push("");
-      lines.push(this.theme.hint(`  Selected (${this.selected.size}):`));
-      for (const p of this.selected) {
-        lines.push(`    ${this.theme.value(p, false)}`);
-      }
-    }
-
-    // Replace the hint line from FuzzySelector
-    const hintIndex = lines.findIndex((l) => l.includes("Type to search"));
-    if (hintIndex !== -1) {
-      lines[hintIndex] = this.theme.hint(
-        "  Type to search · Enter: toggle · Ctrl+S: confirm · Esc: cancel",
-      );
-    }
-
-    return lines;
-  }
-
-  invalidate() {
-    this.fuzzy.invalidate();
-  }
-
-  handleInput(data: string) {
-    if (matchesKey(data, Key.ctrl("s"))) {
-      this.done([...this.selected]);
-      return;
-    }
-    this.fuzzy.handleInput(data);
+  dispose(): void {
+    if (this.timer) clearInterval(this.timer);
   }
 }
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
 
 export function registerSetupCommand(
   pi: ExtensionAPI,
@@ -257,56 +147,81 @@ export function registerSetupCommand(
       }
 
       const config = configLoader.getConfig();
-      const settingsTheme = getSettingsListTheme();
+      const checkGatewayProviders = config.checkGatewayModels ?? [];
 
-      // Step 1: base URL + health check loop.
-      // On failure, loop back to the URL prompt so the user can retry.
-      let baseUrl: string | undefined;
-      while (true) {
-        baseUrl = await ctx.ui.custom<string | undefined>(
-          (_tui, _theme, _kb, done) => {
-            return new UrlPrompt(
-              settingsTheme,
-              baseUrl ?? config.baseUrl,
-              done,
-            );
-          },
-        );
-
-        if (!baseUrl) return;
-        const urlToCheck = baseUrl;
-
-        const result = await ctx.ui.custom<boolean | undefined>(
-          (tui, _theme, _kb, done) => {
-            return new HealthCheckSpinner(settingsTheme, urlToCheck, tui, done);
-          },
-        );
-
-        if (result === true) break; // healthy, proceed
-        if (result === undefined) return; // cancelled
-      }
-
-      // Step 2: select providers
-      // Use model registry so custom/extension providers are included.
       const knownProviders = Array.from(
         new Set(ctx.modelRegistry.getAll().map((model) => model.provider)),
       ).sort((a, b) => a.localeCompare(b));
 
-      const providers = await ctx.ui.custom<string[] | undefined>(
-        (_tui, _theme, _kb, done) => {
-          return new ProviderMultiSelect(
-            settingsTheme,
-            knownProviders,
-            config.providers,
-            done,
-          );
+      let baseUrl = config.baseUrl;
+
+      const providerItems: FuzzyMultiSelectorItem[] = knownProviders.map(
+        (p) => ({
+          label: p,
+          checked: config.providers.includes(p),
+          subOptions: [
+            {
+              label: "verify models on gateway",
+              description:
+                "Warn at startup if this provider's models are missing from the Aperture gateway",
+              checked: checkGatewayProviders.includes(p),
+            },
+          ],
+        }),
+      );
+
+      const confirmed = await ctx.ui.custom<boolean | undefined>(
+        (tui, theme, _kb, done) => {
+          const settingsTheme = getSettingsTheme(theme);
+
+          return new Wizard({
+            title: "Aperture Setup",
+            theme: settingsTheme,
+            minContentHeight: 16,
+            steps: [
+              {
+                label: "URL",
+                build: (wCtx: WizardStepContext) =>
+                  new UrlStep(settingsTheme, tui, baseUrl, wCtx, (url) => {
+                    baseUrl = url;
+                  }),
+              },
+              {
+                label: "Providers",
+                build: (wCtx: WizardStepContext) => {
+                  wCtx.markComplete();
+                  return new FuzzyMultiSelector({
+                    label: "Providers to route through Aperture",
+                    items: providerItems,
+                    theme: settingsTheme,
+                    showHints: false,
+                    showCount: false,
+                    maxVisible: 7,
+                  });
+                },
+              },
+            ],
+            onComplete: () => done(true),
+            onCancel: () => done(undefined),
+          });
         },
       );
 
-      if (!providers) return;
+      if (!confirmed) return;
 
-      // Step 3: save and register
-      await configLoader.save("global", { baseUrl, providers });
+      const providers = providerItems
+        .filter((i) => i.checked)
+        .map((i) => i.label);
+
+      const checkGatewayModels = providerItems
+        .filter((i) => i.checked && i.subOptions?.[0]?.checked)
+        .map((i) => i.label);
+
+      await configLoader.save("global", {
+        baseUrl,
+        providers,
+        checkGatewayModels,
+      });
       onConfigChange(ctx);
       ctx.ui.notify(
         `Aperture configured: ${providers.length} provider(s) via ${baseUrl}`,

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,16 +10,19 @@ import { ConfigLoader } from "@aliou/pi-utils-settings";
 export interface ApertureConfig {
   baseUrl?: string;
   providers?: string[];
+  checkGatewayModels?: string[];
 }
 
 export interface ResolvedConfig {
   baseUrl: string;
   providers: string[];
+  checkGatewayModels: string[];
 }
 
 const DEFAULT_CONFIG: ResolvedConfig = {
   baseUrl: "",
   providers: [],
+  checkGatewayModels: [],
 };
 
 export const configLoader = new ConfigLoader<ApertureConfig, ResolvedConfig>(

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Core module exports -- pure functions and data types.
+ */
+
+export * from "./plan";
+export * from "./types";
+export * from "./url";

--- a/src/core/plan.test.ts
+++ b/src/core/plan.test.ts
@@ -4,18 +4,18 @@ import {
   buildApplyPlan,
   planConfigChange,
   resolveProviderHeaders,
-} from "../../src/core/plan";
-import type { ApertureConfig, ModelInfo } from "../../src/core/types";
+} from "./plan";
+import type { ApertureConfig, Api, Model } from "./types";
 
 describe("resolveProviderHeaders", () => {
   it("includes provenance headers", () => {
-    const models: ModelInfo[] = [{ id: "gpt-4", provider: "openai" }];
+    const models: Model<Api>[] = [{ id: "gpt-4", provider: "openai" }];
     const headers = resolveProviderHeaders(models);
     expect(headers).toMatchObject(APERTURE_PROVENANCE_HEADERS);
   });
 
   it("merges model headers when present", () => {
-    const models: ModelInfo[] = [
+    const models: Model<Api>[] = [
       { id: "gpt-4", provider: "openai", headers: { "X-Custom": "value" } },
     ];
     const headers = resolveProviderHeaders(models);
@@ -26,7 +26,7 @@ describe("resolveProviderHeaders", () => {
   });
 
   it("model headers take precedence over provenance headers", () => {
-    const models: ModelInfo[] = [
+    const models: Model<Api>[] = [
       { id: "gpt-4", provider: "openai", headers: { Referer: "custom" } },
     ];
     const headers = resolveProviderHeaders(models);
@@ -34,7 +34,7 @@ describe("resolveProviderHeaders", () => {
   });
 
   it("uses first model with headers", () => {
-    const models: ModelInfo[] = [
+    const models: Model<Api>[] = [
       { id: "gpt-4", provider: "openai" },
       { id: "gpt-3", provider: "openai", headers: { "X-Auth": "token" } },
       { id: "gpt-4o", provider: "openai", headers: { "X-Other": "other" } },
@@ -45,7 +45,7 @@ describe("resolveProviderHeaders", () => {
   });
 
   it("returns only provenance headers when no model has headers", () => {
-    const models: ModelInfo[] = [
+    const models: Model<Api>[] = [
       { id: "gpt-4", provider: "openai" },
       { id: "gpt-3", provider: "openai" },
     ];
@@ -70,14 +70,14 @@ describe("buildApplyPlan", () => {
   });
 
   it("skips providers with no models in registry", () => {
-    const registryModels: ModelInfo[] = [{ id: "gpt-4", provider: "openai" }];
+    const registryModels: Model<Api>[] = [{ id: "gpt-4", provider: "openai" }];
     const plan = buildApplyPlan(baseConfig, registryModels, baseUrl, []);
     expect(plan.registrations).toHaveLength(1);
     expect(plan.registrations[0].provider).toBe("openai");
   });
 
   it("creates registrations for configured providers with models", () => {
-    const registryModels: ModelInfo[] = [
+    const registryModels: Model<Api>[] = [
       { id: "gpt-4", provider: "openai", api: "openai-completions" },
       { id: "claude-3", provider: "anthropic", api: "anthropic-messages" },
     ];
@@ -88,19 +88,19 @@ describe("buildApplyPlan", () => {
   });
 
   it("registration has correct baseUrl", () => {
-    const registryModels: ModelInfo[] = [{ id: "gpt-4", provider: "openai" }];
+    const registryModels: Model<Api>[] = [{ id: "gpt-4", provider: "openai" }];
     const plan = buildApplyPlan(baseConfig, registryModels, baseUrl, []);
     expect(plan.registrations[0].baseUrl).toBe(baseUrl);
   });
 
   it("registration has apiKey set to dash", () => {
-    const registryModels: ModelInfo[] = [{ id: "gpt-4", provider: "openai" }];
+    const registryModels: Model<Api>[] = [{ id: "gpt-4", provider: "openai" }];
     const plan = buildApplyPlan(baseConfig, registryModels, baseUrl, []);
     expect(plan.registrations[0].apiKey).toBe("-");
   });
 
   it("registration includes merged headers", () => {
-    const registryModels: ModelInfo[] = [
+    const registryModels: Model<Api>[] = [
       { id: "gpt-4", provider: "openai", headers: { "X-Custom": "value" } },
     ];
     const plan = buildApplyPlan(baseConfig, registryModels, baseUrl, []);
@@ -111,7 +111,7 @@ describe("buildApplyPlan", () => {
   });
 
   it("registration uses first model's api", () => {
-    const registryModels: ModelInfo[] = [
+    const registryModels: Model<Api>[] = [
       { id: "gpt-4", provider: "openai", api: "openai-completions" },
       { id: "gpt-3", provider: "openai", api: "openai-chat" },
     ];
@@ -120,13 +120,13 @@ describe("buildApplyPlan", () => {
   });
 
   it("registration defaults api when not specified", () => {
-    const registryModels: ModelInfo[] = [{ id: "gpt-4", provider: "openai" }];
+    const registryModels: Model<Api>[] = [{ id: "gpt-4", provider: "openai" }];
     const plan = buildApplyPlan(baseConfig, registryModels, baseUrl, []);
     expect(plan.registrations[0].api).toBe("openai-completions");
   });
 
   it("registration includes all models for provider", () => {
-    const registryModels: ModelInfo[] = [
+    const registryModels: Model<Api>[] = [
       { id: "gpt-4", provider: "openai" },
       { id: "gpt-3", provider: "openai" },
       { id: "gpt-4o", provider: "openai" },
@@ -136,7 +136,7 @@ describe("buildApplyPlan", () => {
   });
 
   it("computes missing models when gateway IDs provided", () => {
-    const registryModels: ModelInfo[] = [
+    const registryModels: Model<Api>[] = [
       { id: "gpt-4", provider: "openai" },
       { id: "gpt-3", provider: "openai" },
     ];
@@ -151,13 +151,13 @@ describe("buildApplyPlan", () => {
   });
 
   it("missingModels is empty when gateway IDs empty", () => {
-    const registryModels: ModelInfo[] = [{ id: "gpt-4", provider: "openai" }];
+    const registryModels: Model<Api>[] = [{ id: "gpt-4", provider: "openai" }];
     const plan = buildApplyPlan(baseConfig, registryModels, baseUrl, []);
     expect(plan.missingModels).toEqual([]);
   });
 
   it("missingModels is empty when all models present on gateway", () => {
-    const registryModels: ModelInfo[] = [
+    const registryModels: Model<Api>[] = [
       { id: "gpt-4", provider: "openai" },
       { id: "gpt-3", provider: "openai" },
     ];
@@ -176,7 +176,7 @@ describe("buildApplyPlan", () => {
       baseUrl: "https://aperture.example.com",
       providers: ["openai"],
     };
-    const registryModels: ModelInfo[] = [
+    const registryModels: Model<Api>[] = [
       { id: "gpt-4", provider: "openai" },
       { id: "claude-3", provider: "anthropic" },
     ];

--- a/src/core/plan.ts
+++ b/src/core/plan.ts
@@ -1,0 +1,106 @@
+/**
+ * Core decision logic -- all pure functions.
+ */
+
+import type {
+  ApertureConfig,
+  ApplyPlan,
+  ConfigChangePlan,
+  ModelInfo,
+  ProviderRegistration,
+} from "./types";
+
+/**
+ * Preserve provenance similarly to pi-synthetic so downstream providers can
+ * attribute traffic to Pi / this extension.
+ */
+export const APERTURE_PROVENANCE_HEADERS = {
+  Referer: "https://pi.dev",
+  "X-Title": "npm:@aliou/pi-ts-aperture",
+};
+
+/**
+ * Resolves headers for a provider registration.
+ * Merges provenance headers with the first model's headers (if any).
+ */
+export function resolveProviderHeaders(
+  models: ModelInfo[],
+): Record<string, string> {
+  const modelHeaders = models.find((m) => m.headers)?.headers ?? {};
+  return {
+    ...APERTURE_PROVENANCE_HEADERS,
+    ...modelHeaders,
+  };
+}
+
+/**
+ * Builds a plan for applying Aperture configuration.
+ *
+ * Groups registry models by configured provider, builds registrations,
+ * and computes missing models (if gateway model IDs are provided).
+ *
+ * Providers with no models in the registry are skipped (nothing to reroute).
+ */
+export function buildApplyPlan(
+  config: ApertureConfig,
+  registryModels: ModelInfo[],
+  providerBaseUrl: string,
+  gatewayModelIds: string[],
+): ApplyPlan {
+  const { providers } = config;
+
+  const registrations: ProviderRegistration[] = [];
+
+  for (const provider of providers) {
+    const existingModels = registryModels.filter(
+      (m) => m.provider === provider,
+    );
+
+    if (existingModels.length === 0) continue;
+
+    registrations.push({
+      provider,
+      baseUrl: providerBaseUrl,
+      apiKey: "-",
+      headers: resolveProviderHeaders(existingModels),
+      api: existingModels[0].api ?? "openai-completions",
+      models: existingModels,
+    });
+  }
+
+  let missingModels: string[] = [];
+  if (gatewayModelIds.length > 0) {
+    const routedModelIds = registryModels
+      .filter((m) => providers.includes(m.provider))
+      .map((m) => m.id);
+    missingModels = routedModelIds.filter(
+      (id) => !gatewayModelIds.includes(id),
+    );
+  }
+
+  return { registrations, missingModels };
+}
+
+/**
+ * Plans the effects of a configuration change.
+ *
+ * @param prevProviders - Providers that were previously configured
+ * @param nextProviders - Providers that are now configured
+ * @param activeModelProvider - Provider of the currently active model (if any)
+ * @returns ConfigChangePlan with removed providers and refresh decision
+ */
+export function planConfigChange(
+  prevProviders: string[],
+  nextProviders: string[],
+  activeModelProvider?: string,
+): ConfigChangePlan {
+  const removedProviders = prevProviders.filter(
+    (provider) => !nextProviders.includes(provider),
+  );
+
+  const shouldRefreshModel =
+    activeModelProvider !== undefined &&
+    nextProviders.includes(activeModelProvider);
+
+  return { removedProviders, shouldRefreshModel };
+}

--- a/src/core/plan.ts
+++ b/src/core/plan.ts
@@ -4,9 +4,10 @@
 
 import type {
   ApertureConfig,
+  Api,
   ApplyPlan,
   ConfigChangePlan,
-  ModelInfo,
+  Model,
   ProviderRegistration,
 } from "./types";
 
@@ -24,7 +25,7 @@ export const APERTURE_PROVENANCE_HEADERS = {
  * Merges provenance headers with the first model's headers (if any).
  */
 export function resolveProviderHeaders(
-  models: ModelInfo[],
+  models: Model<Api>[],
 ): Record<string, string> {
   const modelHeaders = models.find((m) => m.headers)?.headers ?? {};
   return {
@@ -43,7 +44,7 @@ export function resolveProviderHeaders(
  */
 export function buildApplyPlan(
   config: ApertureConfig,
-  registryModels: ModelInfo[],
+  registryModels: Model<Api>[],
   providerBaseUrl: string,
   gatewayModelIds: string[],
 ): ApplyPlan {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,34 @@
+/**
+ * Plain data types used by core functions. No Pi imports.
+ */
+
+export interface ModelInfo {
+  id: string;
+  provider: string;
+  api?: string;
+  headers?: Record<string, string>;
+}
+
+export interface ApertureConfig {
+  baseUrl: string;
+  providers: string[];
+}
+
+export interface ProviderRegistration {
+  provider: string;
+  baseUrl: string;
+  apiKey: string;
+  headers: Record<string, string>;
+  api: string;
+  models: ModelInfo[];
+}
+
+export interface ApplyPlan {
+  registrations: ProviderRegistration[];
+  missingModels: string[];
+}
+
+export interface ConfigChangePlan {
+  removedProviders: string[];
+  shouldRefreshModel: boolean;
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,17 +1,13 @@
 /**
- * Plain data types used by core functions. No Pi imports.
+ * Plain data types used by core functions.
+ * Model is re-exported from @mariozechner/pi-ai for internal use.
  */
-
-export interface ModelInfo {
-  id: string;
-  provider: string;
-  api?: string;
-  headers?: Record<string, string>;
-}
+import type { Api, Model } from "@mariozechner/pi-ai";
 
 export interface ApertureConfig {
   baseUrl: string;
   providers: string[];
+  checkGatewayModels: string[];
 }
 
 export interface ProviderRegistration {
@@ -20,8 +16,11 @@ export interface ProviderRegistration {
   apiKey: string;
   headers: Record<string, string>;
   api: string;
-  models: ModelInfo[];
+  models: Model<Api>[];
 }
+
+// Re-export Model for use in other core files
+export type { Model, Api };
 
 export interface ApplyPlan {
   registrations: ProviderRegistration[];

--- a/src/core/url.test.ts
+++ b/src/core/url.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
-import type { ApertureConfig } from "../../src/core/types";
+import type { ApertureConfig } from "./types";
 import {
   normalizeInputUrl,
   resolveGatewayUrl,
   resolveProviderBaseUrl,
-} from "../../src/core/url";
+} from "./url";
 
 describe("normalizeInputUrl", () => {
   it("returns empty string for empty input", () => {

--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure URL helpers.
+ */
+
+import type { ApertureConfig } from "./types";
+
+/**
+ * Normalizes a user-input URL:
+ * - Trims whitespace
+ * - Adds http:// scheme if missing
+ * - Strips trailing /v1 or /v1/
+ * - Strips trailing slashes
+ */
+export function normalizeInputUrl(raw: string): string {
+  let result = raw.trim();
+  if (!result) return result;
+  if (!result.startsWith("http://") && !result.startsWith("https://")) {
+    result = `http://${result}`;
+  }
+  return result.replace(/\/v1\/?$/, "").replace(/\/+$/, "");
+}
+
+/**
+ * Returns configured gateway URL without trailing slash.
+ * Returns null when baseUrl is empty or providers list is empty.
+ */
+export function resolveGatewayUrl(config: ApertureConfig): string | null {
+  const { baseUrl, providers } = config;
+  if (!baseUrl || providers.length === 0) return null;
+  return baseUrl.replace(/\/+$/, "");
+}
+
+/**
+ * Returns the Aperture provider base URL used for provider registration.
+ * Appends /v1 to the gateway URL.
+ * Returns null when gateway URL cannot be resolved.
+ */
+export function resolveProviderBaseUrl(config: ApertureConfig): string | null {
+  const gateway = resolveGatewayUrl(config);
+  if (!gateway) return null;
+  return `${gateway}/v1`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,35 +14,81 @@ import type {
 import { registerApertureSettings } from "./commands/settings";
 import { registerSetupCommand } from "./commands/setup";
 import { configLoader } from "./config";
-import { planConfigChange } from "./core";
-import { applyAperture, refreshActiveModel } from "./providers/aperture";
+import { planConfigChange, resolveProviderBaseUrl } from "./core";
+import {
+  applyAperture,
+  checkGatewayModels,
+  refreshActiveModel,
+} from "./providers/aperture";
 
-function registerApertureLifecycleHook(pi: ExtensionAPI): void {
-  const warnedModels = new Set<string>();
+function notifyMissingModelsOnce(
+  ctx: ExtensionContext,
+  missingModels: string[],
+  warnedModels: Set<string>,
+): void {
+  const newMissing = missingModels.filter((id) => !warnedModels.has(id));
+  if (newMissing.length > 0) {
+    for (const id of newMissing) warnedModels.add(id);
+    ctx.ui.notify(
+      `[aperture] models not available on gateway: ${newMissing.join(", ")}. Add them to the gateway configuration.`,
+      "warning",
+    );
+  }
+}
 
+function registerApertureLifecycleHook(
+  pi: ExtensionAPI,
+  warnedModels: Set<string>,
+): void {
   pi.on("before_agent_start", async (_event, ctx) => {
     if (!ctx?.modelRegistry) return;
 
-    const { providers: overriddenProviders, missingModels } =
-      await applyAperture(pi, ctx.modelRegistry);
+    const { providers: overriddenProviders, gatewayUrl } = await applyAperture(
+      pi,
+      ctx.modelRegistry,
+    );
 
-    const newMissing = missingModels.filter((id) => !warnedModels.has(id));
-    if (newMissing.length > 0) {
-      for (const id of newMissing) warnedModels.add(id);
-      ctx.ui.notify(
-        `[aperture] models not available on gateway: ${newMissing.join(", ")}. Add them to the gateway configuration.`,
-        "warning",
+    if (
+      ctx.model &&
+      overriddenProviders.includes(ctx.model.provider) &&
+      gatewayUrl !== null &&
+      configLoader.getConfig().checkGatewayModels.includes(ctx.model.provider)
+    ) {
+      const { missingModels } = await checkGatewayModels(
+        gatewayUrl,
+        ctx.modelRegistry,
       );
+      notifyMissingModelsOnce(ctx, missingModels, warnedModels);
     }
 
     if (!ctx.model || !overriddenProviders.includes(ctx.model.provider)) return;
 
     await refreshActiveModel(pi, ctx);
   });
+
+  // Also check when user switches to a model whose provider uses aperture
+  pi.on("model_select", async (_event, ctx) => {
+    if (!ctx?.model) return;
+
+    const config = configLoader.getConfig();
+    if (!config.providers.includes(ctx.model.provider)) return;
+
+    const gatewayUrl = resolveProviderBaseUrl(config)?.replace("/v1", "");
+    if (!gatewayUrl) return;
+
+    if (config.checkGatewayModels.includes(ctx.model.provider)) {
+      const { missingModels } = await checkGatewayModels(
+        gatewayUrl,
+        ctx.modelRegistry,
+      );
+      notifyMissingModelsOnce(ctx, missingModels, warnedModels);
+    }
+  });
 }
 
 function createConfigChangeHandler(
   pi: ExtensionAPI,
+  warnedModels: Set<string>,
 ): (ctx: ExtensionContext) => void {
   let lastRegisteredProviders = [...configLoader.getConfig().providers];
 
@@ -55,14 +101,24 @@ function createConfigChangeHandler(
       ctx.model?.provider,
     );
 
-    void applyAperture(pi, ctx.modelRegistry).then(({ missingModels }) => {
-      if (missingModels.length > 0) {
-        ctx.ui.notify(
-          `[aperture] models not available on gateway: ${missingModels.join(", ")}. Add them to the gateway configuration.`,
-          "warning",
-        );
-      }
-    });
+    void applyAperture(pi, ctx.modelRegistry).then(
+      async ({ providers, gatewayUrl }) => {
+        if (
+          ctx.model &&
+          providers.includes(ctx.model.provider) &&
+          gatewayUrl !== null &&
+          configLoader
+            .getConfig()
+            .checkGatewayModels.includes(ctx.model.provider)
+        ) {
+          const { missingModels } = await checkGatewayModels(
+            gatewayUrl,
+            ctx.modelRegistry,
+          );
+          notifyMissingModelsOnce(ctx, missingModels, warnedModels);
+        }
+      },
+    );
     lastRegisteredProviders = [...providers];
 
     if (plan.shouldRefreshModel) {
@@ -84,9 +140,11 @@ function createConfigChangeHandler(
 export default async function (pi: ExtensionAPI): Promise<void> {
   await configLoader.load();
 
-  registerApertureLifecycleHook(pi);
+  const warnedModels = new Set<string>();
 
-  const onConfigChange = createConfigChangeHandler(pi);
+  registerApertureLifecycleHook(pi, warnedModels);
+
+  const onConfigChange = createConfigChangeHandler(pi, warnedModels);
   registerSetupCommand(pi, onConfigChange);
   registerApertureSettings(pi, onConfigChange);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import type {
 import { registerApertureSettings } from "./commands/settings";
 import { registerSetupCommand } from "./commands/setup";
 import { configLoader } from "./config";
+import { planConfigChange } from "./core";
 import { applyAperture, refreshActiveModel } from "./providers/aperture";
 
 function registerApertureLifecycleHook(pi: ExtensionAPI): void {
@@ -47,8 +48,11 @@ function createConfigChangeHandler(
 
   return (ctx: ExtensionContext) => {
     const { providers } = configLoader.getConfig();
-    const removedProviders = lastRegisteredProviders.filter(
-      (provider) => !providers.includes(provider),
+
+    const plan = planConfigChange(
+      lastRegisteredProviders,
+      providers,
+      ctx.model?.provider,
     );
 
     void applyAperture(pi, ctx.modelRegistry).then(({ missingModels }) => {
@@ -61,7 +65,7 @@ function createConfigChangeHandler(
     });
     lastRegisteredProviders = [...providers];
 
-    if (ctx.model && providers.includes(ctx.model.provider)) {
+    if (plan.shouldRefreshModel) {
       void refreshActiveModel(pi, ctx).then((updated) => {
         if (!updated) return;
         ctx.ui.notify(
@@ -71,7 +75,7 @@ function createConfigChangeHandler(
       });
     }
 
-    for (const provider of removedProviders) {
+    for (const provider of plan.removedProviders) {
       pi.unregisterProvider(provider);
     }
   };

--- a/src/providers/aperture.ts
+++ b/src/providers/aperture.ts
@@ -4,46 +4,15 @@ import type {
   ProviderModelConfig,
 } from "@mariozechner/pi-coding-agent";
 import { configLoader } from "../config";
+import type { ModelInfo } from "../core";
+import {
+  buildApplyPlan,
+  resolveGatewayUrl,
+  resolveProviderBaseUrl,
+} from "../core";
 import { fetchGatewayModelIds } from "../lib/health";
 
-/**
- * Preserve provenance similarly to pi-synthetic so downstream providers can
- * attribute traffic to Pi / this extension.
- */
-const APERTURE_PROVENANCE_HEADERS = {
-  Referer: "https://pi.dev",
-  "X-Title": "npm:@aliou/pi-ts-aperture",
-};
-
-/** Returns configured gateway URL without trailing slash. */
-export function resolveGatewayUrl(): string | null {
-  const { baseUrl, providers } = configLoader.getConfig();
-  if (!baseUrl || providers.length === 0) return null;
-  return baseUrl.replace(/\/+$/, "");
-}
-
-/**
- * Returns the Aperture provider base URL used for provider registration.
- *
- * Aperture exposes multiple protocol paths (OpenAI, Anthropic, Gemini, ...).
- * For this extension we route through the OpenAI-compatible `/v1` surface that
- * Pi providers use (`openai-completions` API).
- */
-export function resolveApertureProviderBaseUrl(): string | null {
-  const gateway = resolveGatewayUrl();
-  if (!gateway) return null;
-  return `${gateway}/v1`;
-}
-
-function resolveProviderHeaders(
-  models: ProviderModelConfig[],
-): Record<string, string> {
-  const modelHeaders = models.find((m) => m.headers)?.headers ?? {};
-  return {
-    ...APERTURE_PROVENANCE_HEADERS,
-    ...modelHeaders,
-  };
-}
+export { resolveGatewayUrl } from "../core";
 
 /**
  * Apply Aperture override to configured providers.
@@ -58,44 +27,30 @@ export async function applyAperture(
   pi: ExtensionAPI,
   registry: ExtensionContext["modelRegistry"],
 ): Promise<{ providers: string[]; missingModels: string[] }> {
-  const baseUrl = resolveApertureProviderBaseUrl();
+  const config = configLoader.getConfig();
+  const baseUrl = resolveProviderBaseUrl(config);
   if (!baseUrl) return { providers: [], missingModels: [] };
 
-  const { providers } = configLoader.getConfig();
-
-  for (const provider of providers) {
-    const existingModels = registry
-      .getAll()
-      .filter((m) => m.provider === provider) as ProviderModelConfig[];
-
-    if (existingModels.length === 0) continue;
-
-    pi.registerProvider(provider, {
-      baseUrl,
-      apiKey: "-",
-      headers: resolveProviderHeaders(existingModels),
-      api: existingModels[0].api,
-      models: existingModels,
-    });
-  }
-
-  const gatewayUrl = resolveGatewayUrl();
+  const gatewayUrl = resolveGatewayUrl(config);
   const gatewayModelIds = gatewayUrl
     ? await fetchGatewayModelIds(gatewayUrl)
     : [];
 
-  let missingModels: string[] = [];
-  if (gatewayModelIds.length > 0) {
-    const routedModelIds = registry
-      .getAll()
-      .filter((m) => providers.includes(m.provider))
-      .map((m) => m.id);
-    missingModels = routedModelIds.filter(
-      (id) => !gatewayModelIds.includes(id),
-    );
+  const registryModels = registry.getAll() as unknown as ModelInfo[];
+
+  const plan = buildApplyPlan(config, registryModels, baseUrl, gatewayModelIds);
+
+  for (const reg of plan.registrations) {
+    pi.registerProvider(reg.provider, {
+      baseUrl: reg.baseUrl,
+      apiKey: reg.apiKey,
+      headers: reg.headers,
+      api: reg.api,
+      models: reg.models as unknown as ProviderModelConfig[],
+    });
   }
 
-  return { providers, missingModels };
+  return { providers: config.providers, missingModels: plan.missingModels };
 }
 
 /** Re-resolve and set current model after provider registry updates. */

--- a/src/providers/aperture.ts
+++ b/src/providers/aperture.ts
@@ -1,10 +1,8 @@
 import type {
   ExtensionAPI,
   ExtensionContext,
-  ProviderModelConfig,
 } from "@mariozechner/pi-coding-agent";
 import { configLoader } from "../config";
-import type { ModelInfo } from "../core";
 import {
   buildApplyPlan,
   resolveGatewayUrl,
@@ -26,19 +24,16 @@ export { resolveGatewayUrl } from "../core";
 export async function applyAperture(
   pi: ExtensionAPI,
   registry: ExtensionContext["modelRegistry"],
-): Promise<{ providers: string[]; missingModels: string[] }> {
+): Promise<{ providers: string[]; gatewayUrl: string | null }> {
   const config = configLoader.getConfig();
   const baseUrl = resolveProviderBaseUrl(config);
-  if (!baseUrl) return { providers: [], missingModels: [] };
+  if (!baseUrl) return { providers: [], gatewayUrl: null };
 
   const gatewayUrl = resolveGatewayUrl(config);
-  const gatewayModelIds = gatewayUrl
-    ? await fetchGatewayModelIds(gatewayUrl)
-    : [];
 
-  const registryModels = registry.getAll() as unknown as ModelInfo[];
+  const registryModels = registry.getAll();
 
-  const plan = buildApplyPlan(config, registryModels, baseUrl, gatewayModelIds);
+  const plan = buildApplyPlan(config, registryModels, baseUrl, []);
 
   for (const reg of plan.registrations) {
     pi.registerProvider(reg.provider, {
@@ -46,11 +41,28 @@ export async function applyAperture(
       apiKey: reg.apiKey,
       headers: reg.headers,
       api: reg.api,
-      models: reg.models as unknown as ProviderModelConfig[],
+      models: reg.models,
     });
   }
 
-  return { providers: config.providers, missingModels: plan.missingModels };
+  return { providers: config.providers, gatewayUrl };
+}
+
+/**
+ * Fetch gateway models and return missing ones relative to the plan.
+ */
+export async function checkGatewayModels(
+  gatewayUrl: string,
+  registry: ExtensionContext["modelRegistry"],
+): Promise<{ missingModels: string[] }> {
+  const config = configLoader.getConfig();
+  const baseUrl = resolveProviderBaseUrl(config);
+  if (!baseUrl) return { missingModels: [] };
+
+  const gatewayModelIds = await fetchGatewayModelIds(gatewayUrl);
+  const registryModels = registry.getAll();
+  const plan = buildApplyPlan(config, registryModels, baseUrl, gatewayModelIds);
+  return { missingModels: plan.missingModels };
 }
 
 /** Re-resolve and set current model after provider registry updates. */

--- a/tests/core/plan.test.ts
+++ b/tests/core/plan.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from "vitest";
+import {
+  APERTURE_PROVENANCE_HEADERS,
+  buildApplyPlan,
+  planConfigChange,
+  resolveProviderHeaders,
+} from "../../src/core/plan";
+import type { ApertureConfig, ModelInfo } from "../../src/core/types";
+
+describe("resolveProviderHeaders", () => {
+  it("includes provenance headers", () => {
+    const models: ModelInfo[] = [{ id: "gpt-4", provider: "openai" }];
+    const headers = resolveProviderHeaders(models);
+    expect(headers).toMatchObject(APERTURE_PROVENANCE_HEADERS);
+  });
+
+  it("merges model headers when present", () => {
+    const models: ModelInfo[] = [
+      { id: "gpt-4", provider: "openai", headers: { "X-Custom": "value" } },
+    ];
+    const headers = resolveProviderHeaders(models);
+    expect(headers).toEqual({
+      ...APERTURE_PROVENANCE_HEADERS,
+      "X-Custom": "value",
+    });
+  });
+
+  it("model headers take precedence over provenance headers", () => {
+    const models: ModelInfo[] = [
+      { id: "gpt-4", provider: "openai", headers: { Referer: "custom" } },
+    ];
+    const headers = resolveProviderHeaders(models);
+    expect(headers.Referer).toBe("custom");
+  });
+
+  it("uses first model with headers", () => {
+    const models: ModelInfo[] = [
+      { id: "gpt-4", provider: "openai" },
+      { id: "gpt-3", provider: "openai", headers: { "X-Auth": "token" } },
+      { id: "gpt-4o", provider: "openai", headers: { "X-Other": "other" } },
+    ];
+    const headers = resolveProviderHeaders(models);
+    expect(headers["X-Auth"]).toBe("token");
+    expect(headers["X-Other"]).toBeUndefined();
+  });
+
+  it("returns only provenance headers when no model has headers", () => {
+    const models: ModelInfo[] = [
+      { id: "gpt-4", provider: "openai" },
+      { id: "gpt-3", provider: "openai" },
+    ];
+    const headers = resolveProviderHeaders(models);
+    expect(headers).toEqual(APERTURE_PROVENANCE_HEADERS);
+  });
+});
+
+describe("buildApplyPlan", () => {
+  const baseConfig: ApertureConfig = {
+    baseUrl: "https://aperture.example.com",
+    providers: ["openai", "anthropic"],
+  };
+
+  const baseUrl = "https://aperture.example.com/v1";
+
+  it("returns empty registrations for empty config", () => {
+    const config: ApertureConfig = { baseUrl: "", providers: [] };
+    const plan = buildApplyPlan(config, [], baseUrl, []);
+    expect(plan.registrations).toEqual([]);
+    expect(plan.missingModels).toEqual([]);
+  });
+
+  it("skips providers with no models in registry", () => {
+    const registryModels: ModelInfo[] = [{ id: "gpt-4", provider: "openai" }];
+    const plan = buildApplyPlan(baseConfig, registryModels, baseUrl, []);
+    expect(plan.registrations).toHaveLength(1);
+    expect(plan.registrations[0].provider).toBe("openai");
+  });
+
+  it("creates registrations for configured providers with models", () => {
+    const registryModels: ModelInfo[] = [
+      { id: "gpt-4", provider: "openai", api: "openai-completions" },
+      { id: "claude-3", provider: "anthropic", api: "anthropic-messages" },
+    ];
+    const plan = buildApplyPlan(baseConfig, registryModels, baseUrl, []);
+    expect(plan.registrations).toHaveLength(2);
+    expect(plan.registrations.map((r) => r.provider)).toContain("openai");
+    expect(plan.registrations.map((r) => r.provider)).toContain("anthropic");
+  });
+
+  it("registration has correct baseUrl", () => {
+    const registryModels: ModelInfo[] = [{ id: "gpt-4", provider: "openai" }];
+    const plan = buildApplyPlan(baseConfig, registryModels, baseUrl, []);
+    expect(plan.registrations[0].baseUrl).toBe(baseUrl);
+  });
+
+  it("registration has apiKey set to dash", () => {
+    const registryModels: ModelInfo[] = [{ id: "gpt-4", provider: "openai" }];
+    const plan = buildApplyPlan(baseConfig, registryModels, baseUrl, []);
+    expect(plan.registrations[0].apiKey).toBe("-");
+  });
+
+  it("registration includes merged headers", () => {
+    const registryModels: ModelInfo[] = [
+      { id: "gpt-4", provider: "openai", headers: { "X-Custom": "value" } },
+    ];
+    const plan = buildApplyPlan(baseConfig, registryModels, baseUrl, []);
+    expect(plan.registrations[0].headers).toEqual({
+      ...APERTURE_PROVENANCE_HEADERS,
+      "X-Custom": "value",
+    });
+  });
+
+  it("registration uses first model's api", () => {
+    const registryModels: ModelInfo[] = [
+      { id: "gpt-4", provider: "openai", api: "openai-completions" },
+      { id: "gpt-3", provider: "openai", api: "openai-chat" },
+    ];
+    const plan = buildApplyPlan(baseConfig, registryModels, baseUrl, []);
+    expect(plan.registrations[0].api).toBe("openai-completions");
+  });
+
+  it("registration defaults api when not specified", () => {
+    const registryModels: ModelInfo[] = [{ id: "gpt-4", provider: "openai" }];
+    const plan = buildApplyPlan(baseConfig, registryModels, baseUrl, []);
+    expect(plan.registrations[0].api).toBe("openai-completions");
+  });
+
+  it("registration includes all models for provider", () => {
+    const registryModels: ModelInfo[] = [
+      { id: "gpt-4", provider: "openai" },
+      { id: "gpt-3", provider: "openai" },
+      { id: "gpt-4o", provider: "openai" },
+    ];
+    const plan = buildApplyPlan(baseConfig, registryModels, baseUrl, []);
+    expect(plan.registrations[0].models).toHaveLength(3);
+  });
+
+  it("computes missing models when gateway IDs provided", () => {
+    const registryModels: ModelInfo[] = [
+      { id: "gpt-4", provider: "openai" },
+      { id: "gpt-3", provider: "openai" },
+    ];
+    const gatewayIds = ["gpt-4"];
+    const plan = buildApplyPlan(
+      baseConfig,
+      registryModels,
+      baseUrl,
+      gatewayIds,
+    );
+    expect(plan.missingModels).toEqual(["gpt-3"]);
+  });
+
+  it("missingModels is empty when gateway IDs empty", () => {
+    const registryModels: ModelInfo[] = [{ id: "gpt-4", provider: "openai" }];
+    const plan = buildApplyPlan(baseConfig, registryModels, baseUrl, []);
+    expect(plan.missingModels).toEqual([]);
+  });
+
+  it("missingModels is empty when all models present on gateway", () => {
+    const registryModels: ModelInfo[] = [
+      { id: "gpt-4", provider: "openai" },
+      { id: "gpt-3", provider: "openai" },
+    ];
+    const gatewayIds = ["gpt-4", "gpt-3"];
+    const plan = buildApplyPlan(
+      baseConfig,
+      registryModels,
+      baseUrl,
+      gatewayIds,
+    );
+    expect(plan.missingModels).toEqual([]);
+  });
+
+  it("only checks missing models for configured providers", () => {
+    const config: ApertureConfig = {
+      baseUrl: "https://aperture.example.com",
+      providers: ["openai"],
+    };
+    const registryModels: ModelInfo[] = [
+      { id: "gpt-4", provider: "openai" },
+      { id: "claude-3", provider: "anthropic" },
+    ];
+    const gatewayIds: string[] = [];
+    const plan = buildApplyPlan(config, registryModels, baseUrl, gatewayIds);
+    // Only openai models are considered, but since gatewayIds is empty, missingModels is empty
+    expect(plan.missingModels).toEqual([]);
+  });
+});
+
+describe("planConfigChange", () => {
+  it("detects removed providers", () => {
+    const prev = ["openai", "anthropic"];
+    const next = ["openai"];
+    const plan = planConfigChange(prev, next);
+    expect(plan.removedProviders).toEqual(["anthropic"]);
+  });
+
+  it("returns empty removedProviders when no providers removed", () => {
+    const prev = ["openai", "anthropic"];
+    const next = ["openai", "anthropic", "google"];
+    const plan = planConfigChange(prev, next);
+    expect(plan.removedProviders).toEqual([]);
+  });
+
+  it("returns empty removedProviders when providers unchanged", () => {
+    const prev = ["openai", "anthropic"];
+    const next = ["openai", "anthropic"];
+    const plan = planConfigChange(prev, next);
+    expect(plan.removedProviders).toEqual([]);
+  });
+
+  it("detects all providers removed", () => {
+    const prev = ["openai", "anthropic"];
+    const next: string[] = [];
+    const plan = planConfigChange(prev, next);
+    expect(plan.removedProviders).toEqual(["openai", "anthropic"]);
+  });
+
+  it("shouldRefreshModel is true when active model provider is in next providers", () => {
+    const prev = ["openai"];
+    const next = ["openai", "anthropic"];
+    const plan = planConfigChange(prev, next, "openai");
+    expect(plan.shouldRefreshModel).toBe(true);
+  });
+
+  it("shouldRefreshModel is false when active model provider was removed", () => {
+    const prev = ["openai", "anthropic"];
+    const next = ["openai"];
+    const plan = planConfigChange(prev, next, "anthropic");
+    expect(plan.shouldRefreshModel).toBe(false);
+  });
+
+  it("shouldRefreshModel is false when no active model", () => {
+    const prev = ["openai"];
+    const next = ["openai", "anthropic"];
+    const plan = planConfigChange(prev, next);
+    expect(plan.shouldRefreshModel).toBe(false);
+  });
+
+  it("shouldRefreshModel is true when adding provider that matches active model", () => {
+    const prev: string[] = [];
+    const next = ["openai"];
+    const plan = planConfigChange(prev, next, "openai");
+    expect(plan.shouldRefreshModel).toBe(true);
+  });
+
+  it("shouldRefreshModel is false when active model provider not in next", () => {
+    const prev = ["openai"];
+    const next = ["anthropic"];
+    const plan = planConfigChange(prev, next, "openai");
+    expect(plan.shouldRefreshModel).toBe(false);
+  });
+});

--- a/tests/core/url.test.ts
+++ b/tests/core/url.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import type { ApertureConfig } from "../../src/core/types";
+import {
+  normalizeInputUrl,
+  resolveGatewayUrl,
+  resolveProviderBaseUrl,
+} from "../../src/core/url";
+
+describe("normalizeInputUrl", () => {
+  it("returns empty string for empty input", () => {
+    expect(normalizeInputUrl("")).toBe("");
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeInputUrl("  https://example.com  ")).toBe(
+      "https://example.com",
+    );
+  });
+
+  it("adds http:// scheme when missing", () => {
+    expect(normalizeInputUrl("example.com")).toBe("http://example.com");
+  });
+
+  it("preserves https:// scheme", () => {
+    expect(normalizeInputUrl("https://example.com")).toBe(
+      "https://example.com",
+    );
+  });
+
+  it("preserves http:// scheme", () => {
+    expect(normalizeInputUrl("http://example.com")).toBe("http://example.com");
+  });
+
+  it("strips trailing /v1", () => {
+    expect(normalizeInputUrl("https://example.com/v1")).toBe(
+      "https://example.com",
+    );
+  });
+
+  it("strips trailing /v1/", () => {
+    expect(normalizeInputUrl("https://example.com/v1/")).toBe(
+      "https://example.com",
+    );
+  });
+
+  it("strips trailing slashes", () => {
+    expect(normalizeInputUrl("https://example.com/")).toBe(
+      "https://example.com",
+    );
+  });
+
+  it("strips multiple trailing slashes", () => {
+    expect(normalizeInputUrl("https://example.com///")).toBe(
+      "https://example.com",
+    );
+  });
+
+  it("handles already-normalized URL", () => {
+    expect(normalizeInputUrl("https://example.com")).toBe(
+      "https://example.com",
+    );
+  });
+});
+
+describe("resolveGatewayUrl", () => {
+  it("returns null when baseUrl is empty", () => {
+    const config: ApertureConfig = { baseUrl: "", providers: ["openai"] };
+    expect(resolveGatewayUrl(config)).toBeNull();
+  });
+
+  it("returns null when providers is empty", () => {
+    const config: ApertureConfig = {
+      baseUrl: "https://example.com",
+      providers: [],
+    };
+    expect(resolveGatewayUrl(config)).toBeNull();
+  });
+
+  it("returns null when both baseUrl and providers are empty", () => {
+    const config: ApertureConfig = { baseUrl: "", providers: [] };
+    expect(resolveGatewayUrl(config)).toBeNull();
+  });
+
+  it("returns URL without trailing slash", () => {
+    const config: ApertureConfig = {
+      baseUrl: "https://example.com/",
+      providers: ["openai"],
+    };
+    expect(resolveGatewayUrl(config)).toBe("https://example.com");
+  });
+
+  it("returns URL as-is when no trailing slash", () => {
+    const config: ApertureConfig = {
+      baseUrl: "https://example.com",
+      providers: ["openai"],
+    };
+    expect(resolveGatewayUrl(config)).toBe("https://example.com");
+  });
+
+  it("strips multiple trailing slashes", () => {
+    const config: ApertureConfig = {
+      baseUrl: "https://example.com///",
+      providers: ["openai"],
+    };
+    expect(resolveGatewayUrl(config)).toBe("https://example.com");
+  });
+});
+
+describe("resolveProviderBaseUrl", () => {
+  it("returns null when gateway URL cannot be resolved", () => {
+    const config: ApertureConfig = { baseUrl: "", providers: ["openai"] };
+    expect(resolveProviderBaseUrl(config)).toBeNull();
+  });
+
+  it("appends /v1 to gateway URL", () => {
+    const config: ApertureConfig = {
+      baseUrl: "https://example.com",
+      providers: ["openai"],
+    };
+    expect(resolveProviderBaseUrl(config)).toBe("https://example.com/v1");
+  });
+
+  it("handles trailing slashes correctly", () => {
+    const config: ApertureConfig = {
+      baseUrl: "https://example.com/",
+      providers: ["openai"],
+    };
+    expect(resolveProviderBaseUrl(config)).toBe("https://example.com/v1");
+  });
+});

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -1,7 +1,7 @@
 /**
- * End-to-end tests for pi-ts-aperture.
+ * End-to-end tests for pi-ts-aperture using RPC mode.
  *
- * Spawns the real PI CLI and verifies that:
+ * Spawns the real PI CLI in RPC mode and verifies that:
  * 1. Models are correctly enumerated without aperture
  * 2. After configuring aperture, the same models are still present
  * 3. Model metadata is preserved through the override
@@ -106,10 +106,6 @@ describe("pi-ts-aperture e2e", () => {
     process.env.ANTHROPIC_API_KEY ??= "sk-test-anthropic";
     process.env.OPENAI_API_KEY ??= "sk-test-openai";
 
-    // Avoid npm permission issues in temp dirs.
-    process.env.NPM_CONFIG_PREFIX = join(testRoot, "npm-global");
-    mkdirSync(process.env.NPM_CONFIG_PREFIX, { recursive: true });
-
     setupTestProvider(paths.testProviderDir, paths.testProviderEntry);
   });
 
@@ -192,12 +188,12 @@ describe("pi-ts-aperture e2e", () => {
       (m) => m.id === "test-model-1" && m.provider === "test-provider",
     );
     expect(model1).toBeDefined();
-    expect(model1?.thinking).toBe("no");
+    expect(model1?.reasoning).toBe(false);
 
     const model2 = models.find(
       (m) => m.id === "test-model-2" && m.provider === "test-provider",
     );
     expect(model2).toBeDefined();
-    expect(model2?.thinking).toBe("yes");
+    expect(model2?.reasoning).toBe(true);
   });
 });

--- a/tests/pi-cli.ts
+++ b/tests/pi-cli.ts
@@ -1,113 +1,65 @@
 /**
- * Thin wrapper around the PI CLI for e2e tests.
- * Spawns `pi` with isolated config and parses tabular output.
+ * RPC Client for Pi e2e tests.
+ * Uses RpcClient from pi-coding-agent to spawn pi in RPC mode
+ * and provides typed access to models.
  */
 
-import { execSync } from "node:child_process";
-import { mkdtempSync, realpathSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { resolve } from "node:path";
+import { type ModelInfo, RpcClient } from "@mariozechner/pi-coding-agent/modes";
 
-export interface ModelRow {
-  provider: string;
-  id: string;
-  context: string;
-  maxOut: string;
-  thinking: string;
-  images: string;
-}
+export type { ModelInfo };
+
+/**
+ * Absolute path to the pi CLI entry point (local node_modules install).
+ * RpcClient spawns `node <cliPath>`, so we provide the resolved absolute path.
+ */
+const PI_CLI_PATH = resolve(
+  "node_modules/@mariozechner/pi-coding-agent/dist/cli.js",
+);
 
 export class PiCli {
-  private configDir: string;
-  private piBin: string;
-  private extensionPaths: string[];
+  private rpc: RpcClient;
 
   constructor(
-    options: {
-      piBin?: string;
-      configDir?: string;
+    private options: {
       extensionPaths?: string[];
+      env?: Record<string, string>;
     } = {},
   ) {
-    this.configDir =
-      options.configDir ??
-      mkdtempSync(join(realpathSync(tmpdir()), "pi-test-"));
-    this.piBin = options.piBin ?? "pi";
-    this.extensionPaths = options.extensionPaths ?? [];
-
-    writeFileSync(
-      join(this.configDir, "settings.json"),
-      JSON.stringify({ enabledModels: undefined }),
-    );
-  }
-
-  run(args: string[], env?: Record<string, string>): string {
-    const extensionArgs = this.extensionPaths.flatMap((p) => [
-      "--extension",
-      p,
-    ]);
-    const fullArgs = [
-      "--config-dir",
-      this.configDir,
-      ...extensionArgs,
-      "--no-extensions",
-      ...args,
-    ];
-
-    const command = `${this.piBin} ${fullArgs.map((a) => `"${a}"`).join(" ")}`;
-
-    try {
-      return execSync(command, {
-        env: { ...process.env, ...env, NODE_ENV: "test" },
-        encoding: "utf-8",
-        timeout: 30_000,
-      });
-    } catch (error: unknown) {
-      if (error instanceof Error && "stdout" in error) {
-        return (error as { stdout: string }).stdout;
-      }
-      throw error;
+    const extraArgs: string[] = ["--no-extensions"];
+    for (const ext of this.options.extensionPaths ?? []) {
+      extraArgs.push("--extension", ext);
     }
+
+    this.rpc = new RpcClient({
+      cliPath: PI_CLI_PATH,
+      env: this.options.env,
+      args: extraArgs,
+    });
   }
 
-  listModels(): ModelRow[] {
-    const output = this.run(["--list-models"]);
-    return parseModelsTable(output);
+  async start(): Promise<void> {
+    await this.rpc.start();
+  }
+
+  async stop(): Promise<void> {
+    await this.rpc.stop();
+  }
+
+  async listModels(): Promise<ModelInfo[]> {
+    return this.rpc.getAvailableModels();
   }
 }
 
-/**
- * Parse the tabular output from `pi --list-models`.
- * Columns are separated by 2+ spaces.
- */
-function parseModelsTable(output: string): ModelRow[] {
-  const lines = output.trim().split("\n");
-  // Skip header line
-  return lines.slice(1).reduce<ModelRow[]>((rows, line) => {
-    if (!line.trim()) return rows;
-
-    const parts = line.trim().split(/\s{2,}/);
-    if (parts.length >= 6) {
-      rows.push({
-        provider: parts[0].trim(),
-        id: parts[1].trim(),
-        context: parts[2].trim(),
-        maxOut: parts[3].trim(),
-        thinking: parts[4].trim(),
-        images: parts[5].trim(),
-      });
-    }
-    return rows;
-  }, []);
-}
-
-/**
- * Run a test callback with a PiCli instance.
- */
 export async function withPiCli<T>(
   options: ConstructorParameters<typeof PiCli>[0],
-  fn: (cli: PiCli) => Promise<T> | T,
+  fn: (cli: PiCli) => Promise<T>,
 ): Promise<T> {
   const cli = new PiCli(options);
-  return fn(cli);
+  await cli.start();
+  try {
+    return await fn(cli);
+  } finally {
+    await cli.stop();
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "noEmit": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/*.test.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,18 @@
+import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@mariozechner/pi-coding-agent/modes": resolve(
+        "node_modules/@mariozechner/pi-coding-agent/dist/modes/index.js",
+      ),
+    },
+  },
   test: {
     testTimeout: 60_000,
     hookTimeout: 30_000,
-    include: ["tests/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "tests/**/*.test.ts"],
+    mockReset: true,
   },
 });


### PR DESCRIPTION
## Summary

Move all decision-making logic into pure functions that accept and return plain data. The Pi extension becomes a thin adapter that reads state, calls core, and applies side effects.

## Changes

### Core module (src/core/)
- **types.ts**: Plain data types (ModelInfo, ApertureConfig, ProviderRegistration, ApplyPlan, ConfigChangePlan)
- **url.ts**: Pure URL helpers (normalizeInputUrl, resolveGatewayUrl, resolveProviderBaseUrl)
- **plan.ts**: Core decision logic (buildApplyPlan, planConfigChange, resolveProviderHeaders)

### Modified adapters
- **providers/aperture.ts**: Thin adapter using core functions
- **commands/setup.ts**: Uses normalizeInputUrl from core
- **index.ts**: Uses planConfigChange for config change handling

### Additional improvements
- Update to Pi 0.64.0
- Replace ModelInfo with Model<Api> from pi-ai
- Co-locate unit tests with source files (*.test.ts)
- Rewrite e2e tests to use RpcClient
- Add per-provider gateway model checking
- Rewrite setup wizard with Wizard + FuzzyMultiSelector
- Add gateway model checking to settings UI

### Tests
- 50 tests pass (4 e2e + 46 core unit tests)
- All core logic is unit-testable with no Pi dependencies