### PR TITLE
fix: tolerate admin-only /aperture/config for non-admin grants

### DIFF
--- a/.changeset/non-admin-aperture-config.md
+++ b/.changeset/non-admin-aperture-config.md
@@ -1,0 +1,10 @@
+---
+"@aliou/pi-ts-aperture": patch
+---
+
+Tolerate the admin-only `/aperture/config` endpoint so non-admin Aperture grants can use the extension.
+
+- `ApertureClient._fetch` now throws an `ApertureHttpError` that carries the HTTP status, so callers can tolerate specific responses.
+- `providerConfigInfos()` (and `providerBaseUrls()`) return an empty map on HTTP 403 instead of throwing. `/aperture/config` requires `role:admin` and is the only endpoint a non-admin grant cannot access; everything else (`/api/providers`, `/api/connectors`, `/v1/mcp`, model calls) returns 200 for non-admin grants.
+- Proxy provider matching already falls back to IDs via `/api/providers` when provider config info is empty, so onboarding and the proxy settings submenu keep working for non-admin users. Admin users keep the richer base-URL matching. Dedicated mode and connectors never read `/aperture/config` and are unaffected.
+- Other non-403 errors still propagate.

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { ApertureClient } from "./client";
+import { ApertureClient, ApertureHttpError } from "./client";
 
 describe("ApertureClient", () => {
   afterEach(() => {
@@ -124,5 +124,103 @@ describe("ApertureClient", () => {
     await expect(
       new ApertureClient("http://gateway.test").providerBaseUrls(),
     ).resolves.toEqual(new Map([["anthropic", "https://api.anthropic.com"]]));
+  });
+
+  // /aperture/config is admin-only on the gateway: a non-admin grant
+  // (role:user) gets 403 while still being able to call /api/providers and
+  // /v1/mcp. The client must not break proxy/dedicated flows for those users.
+
+  test("providerConfigInfos() returns empty map on 403", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+      }),
+    );
+
+    await expect(
+      new ApertureClient("http://gateway.test").providerConfigInfos(),
+    ).resolves.toEqual(new Map());
+  });
+
+  test("providerBaseUrls() returns empty map on 403", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+      }),
+    );
+
+    await expect(
+      new ApertureClient("http://gateway.test").providerBaseUrls(),
+    ).resolves.toEqual(new Map());
+  });
+
+  test("providerConfigInfos() rethrows non-403 errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      }),
+    );
+
+    await expect(
+      new ApertureClient("http://gateway.test").providerConfigInfos(),
+    ).rejects.toBeInstanceOf(ApertureHttpError);
+  });
+
+  test("proxy provider fetch path resolves when /aperture/config is 403 but /api/providers is 200", async () => {
+    // Mirrors how onboarding/settings fetch proxy providers:
+    //   Promise.all([providerConfigInfos(), providers()])
+    // A non-admin grant gets 403 on /aperture/config yet 200 on /api/providers,
+    // so the combined fetch must not reject.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        if (url.endsWith("/aperture/config")) {
+          return Promise.resolve({
+            ok: false,
+            status: 403,
+            statusText: "Forbidden",
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            providers: [
+              {
+                id: "anthropic",
+                name: "Anthropic",
+                description: "Claude models",
+                models: ["claude-3-5-sonnet"],
+                compatibility: { anthropic_messages: true },
+              },
+            ],
+          }),
+        });
+      }),
+    );
+
+    const client = new ApertureClient("http://gateway.test");
+    await expect(
+      Promise.all([client.providerConfigInfos(), client.providers()]),
+    ).resolves.toEqual([
+      new Map(),
+      [
+        {
+          id: "anthropic",
+          name: "Anthropic",
+          description: "Claude models",
+          models: ["claude-3-5-sonnet"],
+          compatibility: { anthropic_messages: true },
+        },
+      ],
+    ]);
   });
 });

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -31,6 +31,26 @@ function parseProvider(
   });
 }
 
+/**
+ * HTTP error raised by {@link ApertureClient._fetch}. Carries the status
+ * code so callers can tolerate specific responses — for example the 403 that
+ * the admin-only `/aperture/config` endpoint returns to non-admin grants.
+ */
+export class ApertureHttpError extends Error {
+  readonly status: number;
+
+  constructor(
+    method: string,
+    path: string,
+    status: number,
+    statusText: string,
+  ) {
+    super(`[Aperture] ${method} ${path}: -> ${status} ${statusText}`);
+    this.name = "ApertureHttpError";
+    this.status = status;
+  }
+}
+
 export class ApertureClient {
   private readonly baseUrl: string;
 
@@ -57,9 +77,7 @@ export class ApertureClient {
 
     const res = await fetch(url, { method, signal: composedSignal });
     if (!res.ok) {
-      throw new Error(
-        `[Aperture] ${method} ${path}: -> ${res.status} ${res.statusText}`,
-      );
+      throw new ApertureHttpError(method, path, res.status, res.statusText);
     }
     return res.json() as T;
   }
@@ -96,9 +114,24 @@ export class ApertureClient {
   async providerConfigInfos(
     signal?: AbortSignal,
   ): Promise<Map<string, ApertureProviderConfigInfo>> {
-    const body = await this._fetch<{ config?: unknown }>("/aperture/config", {
-      signal,
-    });
+    // `/aperture/config` is admin-only on the Aperture gateway (requires
+    // role:admin). Non-admin grants get HTTP 403 and have no access to the
+    // upstream provider base URLs. We tolerate that and return an empty
+    // map so the rest of the client keeps working: proxy provider matching
+    // falls back to IDs via `/api/providers`, which non-admin grants can
+    // access (and dedicated mode never reads this endpoint). Any other
+    // failure still propagates.
+    let body: { config?: unknown };
+    try {
+      body = await this._fetch<{ config?: unknown }>("/aperture/config", {
+        signal,
+      });
+    } catch (error) {
+      if (error instanceof ApertureHttpError && error.status === 403) {
+        return new Map();
+      }
+      throw error;
+    }
     let config = body.config;
     if (typeof config === "string") {
       try {

--- a/src/provider-mapping.test.ts
+++ b/src/provider-mapping.test.ts
@@ -1,0 +1,131 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { describe, expect, test } from "vitest";
+import type { ApertureProvider, ApertureProviderConfigInfo } from "./api/types";
+import { mapProxyProviders } from "./provider-mapping";
+
+function localModel(
+  provider: string,
+  baseUrl: string,
+  id = `${provider}-model`,
+): Model<Api> {
+  return {
+    id,
+    name: id,
+    api: "openai-completions",
+    provider,
+    baseUrl,
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 8_192,
+  };
+}
+
+function gatewayProvider(id: string): ApertureProvider {
+  return {
+    id,
+    name: id,
+    description: "",
+    models: [`${id}-model`],
+    compatibility: { openai_chat: true },
+  };
+}
+
+describe("mapProxyProviders", () => {
+  test("matches local providers by gateway ID when config info is empty (non-admin grant)", () => {
+    // Non-admin grants get 403 on /aperture/config, so providerConfigInfos()
+    // returns an empty map. proxy matching must still work via IDs, which
+    // come from /api/providers (accessible to non-admin grants).
+    const localModels = [
+      localModel("anthropic", "https://api.anthropic.com"),
+      localModel("openai", "https://api.openai.com"),
+      localModel("unmatched", "https://example.com"),
+    ];
+    const gatewayProviders = [
+      gatewayProvider("anthropic"),
+      gatewayProvider("openai"),
+    ];
+
+    const result = mapProxyProviders(
+      localModels,
+      new Map(),
+      gatewayProviders,
+      [],
+    );
+
+    expect(result.map((p) => p.id)).toEqual(["anthropic", "openai"]);
+    // name resolved from gateway providers when config info is absent
+    expect(result[0]).toMatchObject({ id: "anthropic", name: "anthropic" });
+    // gateway model check defaults to on
+    expect(result[0].shouldCheckGatewayModels).toBe(true);
+  });
+
+  test("returns nothing when no local provider matches a gateway provider ID", () => {
+    const localModels = [localModel("unmatched", "https://example.com")];
+    const gatewayProviders = [gatewayProvider("anthropic")];
+
+    const result = mapProxyProviders(
+      localModels,
+      new Map(),
+      gatewayProviders,
+      [],
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  test("matches local providers by base URL when config info is populated (admin)", () => {
+    const localModels = [
+      localModel("anthropic", "https://api.anthropic.com/v1"),
+      localModel("openrouter", "https://openrouter.ai/api"),
+      localModel("excluded", "https://nowhere.example.com"),
+    ];
+    const providerInfos = new Map<string, ApertureProviderConfigInfo>([
+      [
+        "anthropic",
+        {
+          id: "anthropic",
+          name: "Anthropic",
+          baseUrl: "https://api.anthropic.com",
+        },
+      ],
+      [
+        "openrouter",
+        {
+          id: "openrouter",
+          name: "OpenRouter",
+          baseUrl: "https://openrouter.ai/api/",
+        },
+      ],
+    ]);
+    const gatewayProviders = [gatewayProvider("anthropic")];
+
+    const result = mapProxyProviders(
+      localModels,
+      providerInfos,
+      gatewayProviders,
+      [],
+    );
+
+    // Already sorted by id by collectLocalProviders.
+    expect(result.map((p) => p.id)).toEqual(["anthropic", "openrouter"]);
+    // Gateway provider name takes precedence over the config name when both exist.
+    expect(result.find((p) => p.id === "anthropic")?.name).toBe("anthropic");
+    // Config name used for the URL-matched provider that is not a gateway provider.
+    expect(result.find((p) => p.id === "openrouter")?.name).toBe("OpenRouter");
+    // No URL or ID match -> filtered out.
+    expect(result.some((p) => p.id === "excluded")).toBe(false);
+  });
+
+  test("preserves existing shouldCheckGatewayModels setting", () => {
+    const localModels = [localModel("anthropic", "https://api.anthropic.com")];
+    const gatewayProviders = [gatewayProvider("anthropic")];
+
+    const result = mapProxyProviders(localModels, new Map(), gatewayProviders, [
+      { id: "anthropic", shouldCheckGatewayModels: false },
+    ]);
+
+    expect(result[0].shouldCheckGatewayModels).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

`/aperture/config` requires `role:admin` on the Aperture gateway. A non-admin grant (`role:user`, `models: "**"`, `connectors: ["**"]`) gets HTTP 403 there while still able to call `/api/providers`, `/api/connectors`, `/v1/mcp`, and model calls (all 200). This made the extension unusable for non-admin users: any proxy discovery flow (`providerConfigInfos()`) rejected, which took down onboarding and the proxy settings submenu.

## Changes

- `ApertureClient._fetch` now throws a status-carrying `ApertureHttpError` so callers can tolerate specific responses. Error message format is unchanged, so `async-editor.ts`'s `summarizeError` regex still works.
- `providerConfigInfos()` (and `providerBaseUrls()`) return an empty `Map` on HTTP 403 instead of throwing. All other errors still propagate.
- Proxy matching (`mapProxyProviders`) already falls back to IDs via `/api/providers` when provider config info is empty, so onboarding and the proxy settings submenu keep working for non-admin users. No change needed there — covered by new tests.

## Why no change in provider-mapping.ts / dedicated / connectors

- `mapProxyProviders` matches by gateway provider ID when config info is empty (from `/api/providers`, accessible to non-admins) and by base URL when config is present. Empty map just disables URL matching and keeps ID matching.
- Dedicated mode reads `/api/providers` (with `compatibility`), never `/aperture/config`. Unaffected.
- Connectors use `/v1/mcp`. Unaffected.
- Admin users keep the richer base-URL matching. No regression.

## Tests

- `providerConfigInfos()` / `providerBaseUrls()` return empty map on 403.
- `providerConfigInfos()` rethrows non-403 errors as `ApertureHttpError`.
- Combined `Promise.all([providerConfigInfos(), providers()])` (onboarding/settings fetch path) resolves when `/aperture/config` is 403 but `/api/providers` is 200.
- `mapProxyProviders`: ID matching with empty config info (non-admin), no-match exclusion, admin base-URL matching with name resolution (no regression), and `shouldCheckGatewayModels` preservation.

checks: `pnpm typecheck` ✓, `pnpm lint` ✓, `pnpm test` 57/57 ✓.

Fixes https://github.com/aliou/pi-ts-aperture/issues/28