### PR TITLE
feat(dedicated): wire /v1/models pricing into model costs

### DIFF
--- a/.changeset/dedicated-model-pricing.md
+++ b/.changeset/dedicated-model-pricing.md
@@ -1,0 +1,7 @@
+---
+"@aliou/pi-ts-aperture": patch
+---
+
+Wire `/v1/models` pricing into dedicated provider model costs.
+
+Dedicated mode was registering every gateway model with zero cost because `/v1/models` was only used as an enabled-model filter and its `pricing` object was discarded. The client now retains each model's pricing on `modelInfoById`, and the dedicated runtime passes it through to `buildDefaultModelConfig`, so per-token USD values are converted to per-million costs on registered models and persisted to the dedicated models cache.

--- a/extensions/aperture/dedicated/model-defaults.ts
+++ b/extensions/aperture/dedicated/model-defaults.ts
@@ -1,4 +1,5 @@
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import type { ApertureModelPricing } from "../../../src/api/types";
 
 export interface ApertureModelDefaultsInput {
   id: string;
@@ -7,12 +8,7 @@ export interface ApertureModelDefaultsInput {
     id: string;
     name?: string;
   };
-  pricing?: {
-    input?: string;
-    input_cache_read?: string;
-    input_cache_write?: string;
-    output?: string;
-  };
+  pricing?: ApertureModelPricing;
 }
 
 const TOKENS_PER_MILLION = 1_000_000;

--- a/extensions/aperture/dedicated/runtime.test.ts
+++ b/extensions/aperture/dedicated/runtime.test.ts
@@ -77,6 +77,17 @@ function gatewayProvider(id: string, models: string[]): ApertureProvider {
   };
 }
 
+function gatewayProviderWithPricing(
+  id: string,
+  modelId: string,
+  pricing: Record<string, string>,
+): ApertureProvider {
+  return {
+    ...gatewayProvider(id, [modelId]),
+    modelInfoById: { [modelId]: { id: modelId, pricing } },
+  };
+}
+
 function captureRegistered(
   registerProvider: ReturnType<typeof vi.fn>,
 ): { models: ProviderModelConfig[]; streamSimple?: unknown } | null {
@@ -248,5 +259,36 @@ describe("DedicatedRuntime.syncConfig", () => {
 
     expect(providersMock).not.toHaveBeenCalled();
     expect(registerProvider).not.toHaveBeenCalled();
+  });
+
+  // Gateway providers carry pricing from /v1/models via modelInfoById; that
+  // pricing should be converted to per-million-token costs on the registered
+  // model configs and persisted to the cache.
+  test("attaches pricing from modelInfoById to model cost and cache", async () => {
+    providersMock.mockResolvedValue([
+      gatewayProviderWithPricing("synthetic", "syn:large:text", {
+        input: "0.00000093",
+        input_cache_read: "0.00000018",
+        input_cache_write: "0.00000300",
+        input_cache_write_1h: "0.00000600",
+        output: "0.00000300",
+        web_search: "0.01000000",
+      }),
+    ]);
+    const registerProvider = vi.fn();
+    await new DedicatedRuntime().sync({ registerProvider });
+
+    const { models } = captureRegistered(registerProvider) ?? { models: [] };
+    expect(models).toHaveLength(1);
+    expect(models[0].cost?.input).toBeCloseTo(0.93, 10);
+    expect(models[0].cost?.output).toBe(3);
+    expect(models[0].cost?.cacheRead).toBeCloseTo(0.18, 10);
+    expect(models[0].cost?.cacheWrite).toBe(3);
+    expect(writeCachedDedicatedModels).toHaveBeenCalledOnce();
+    const [, cachedModels] = writeCachedDedicatedModels.mock.calls[0];
+    expect(cachedModels[0].cost?.input).toBeCloseTo(0.93, 10);
+    expect(cachedModels[0].cost?.output).toBe(3);
+    expect(cachedModels[0].cost?.cacheRead).toBeCloseTo(0.18, 10);
+    expect(cachedModels[0].cost?.cacheWrite).toBe(3);
   });
 });

--- a/extensions/aperture/dedicated/runtime.ts
+++ b/extensions/aperture/dedicated/runtime.ts
@@ -59,11 +59,13 @@ function buildModels(
     const api = getApiForCompatibility(provider.compatibility);
     for (const modelId of provider.models) {
       routeByModelId.set(modelId, { api });
+      const modelInfo = provider.modelInfoById?.[modelId];
       models.push({
         ...buildDefaultModelConfig({
           id: modelId,
           providerId: provider.id,
           provider: { id: provider.id, name: provider.name },
+          pricing: modelInfo?.pricing,
         }),
         api: APERTURE_API,
         baseUrl: getBaseUrlForApi(api, gatewayUrl, baseUrl),

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -28,6 +28,10 @@ describe("ApertureClient", () => {
     return { data: ids.map((id) => ({ id, object: "model" })) };
   }
 
+  function modelWithPricing(id: string, pricing: Record<string, string>) {
+    return { id, object: "model", pricing };
+  }
+
   function providersArray(...providers: Record<string, unknown>[]) {
     return { providers };
   }
@@ -76,6 +80,7 @@ describe("ApertureClient", () => {
         // claude-internal is not in /v1/models -> intersected out
         models: ["claude-3-5-sonnet"],
         compatibility: { anthropic_messages: true },
+        modelInfoById: { "claude-3-5-sonnet": { id: "claude-3-5-sonnet" } },
       },
     ]);
   });
@@ -116,6 +121,7 @@ describe("ApertureClient", () => {
         description: "",
         models: ["openai/gpt-5"],
         compatibility: { openai_chat: true },
+        modelInfoById: { "openai/gpt-5": { id: "openai/gpt-5" } },
       },
     ]);
   });
@@ -163,5 +169,41 @@ describe("ApertureClient", () => {
     await expect(
       new ApertureClient("http://gateway.test").providers(),
     ).rejects.toBeInstanceOf(ApertureHttpError);
+  });
+
+  // /v1/models entries carry a `pricing` object; providers() should retain it
+  // on `modelInfoById` so dedicated mode can build cost-aware model configs.
+  test("providers() retains /v1/models pricing on modelInfoById", async () => {
+    const pricing = {
+      input: "0.00000100",
+      input_cache_read: "0.00000010",
+      input_cache_write: "0.00000125",
+      input_cache_write_1h: "0.00000200",
+      output: "0.00000500",
+      web_search: "0.01000000",
+    };
+    mockFetch((url) => {
+      if (url.endsWith("/api/providers")) {
+        return providersArray({
+          id: "synthetic",
+          name: "Synthetic",
+          description: "",
+          models: ["syn:large:text"],
+          compatibility: { openai_chat: true },
+        });
+      }
+      if (url.endsWith("/v1/models")) {
+        return { data: [modelWithPricing("syn:large:text", pricing)] };
+      }
+      return notOk(404, "Not Found");
+    });
+
+    const providers = await new ApertureClient(
+      "http://gateway.test",
+    ).providers();
+    expect(providers[0].modelInfoById?.["syn:large:text"]).toEqual({
+      id: "syn:large:text",
+      pricing,
+    });
   });
 });

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,6 +1,7 @@
 import type { TSchema } from "typebox";
 import { Value } from "typebox/value";
 import {
+  type ApertureModelInfo,
   type ApertureProvider,
   ApertureProviderSchema,
   type ConnectorInfo,
@@ -103,47 +104,63 @@ export class ApertureClient {
   }
 
   /**
-   * Set of model ids exposed by `/v1/models`.
+   * Models exposed by `/v1/models`, keyed by id.
    *
    * Disabled providers' models do not appear in `/v1/models`, so this is the
-   * source of truth for which gateway providers are usable. Failures (network,
-   * 404, ...) resolve to an empty set, which leaves the `/api/providers`
-   * result unfiltered as a safe fallback.
+   * source of truth for which gateway providers are usable. The full entry
+   * (including `pricing`) is retained so dedicated mode can attach costs to
+   * model configs without re-fetching the gateway. Failures (network, 404, ...)
+   * resolve to an empty map, which leaves the `/api/providers` result
+   * unfiltered as a safe fallback.
    */
-  private async enabledModelIds(signal?: AbortSignal): Promise<Set<string>> {
+  private async enabledModelsById(
+    signal?: AbortSignal,
+  ): Promise<Map<string, ApertureModelInfo>> {
     try {
       const body = await this._fetch<{ data?: unknown[] }>("/v1/models", {
         signal,
       });
-      if (!Array.isArray(body.data)) return new Set();
-      const ids = new Set<string>();
+      if (!Array.isArray(body.data)) return new Map();
+      const byId = new Map<string, ApertureModelInfo>();
       for (const entry of body.data) {
         if (!entry || typeof entry !== "object") continue;
-        const id = (entry as Record<string, unknown>).id;
-        if (typeof id === "string") ids.add(id);
+        const record = entry as Record<string, unknown>;
+        const id = record.id;
+        if (typeof id !== "string") continue;
+        byId.set(id, {
+          id,
+          pricing: record.pricing as ApertureModelInfo["pricing"] | undefined,
+        });
       }
-      return ids;
+      return byId;
     } catch {
-      return new Set();
+      return new Map();
     }
   }
 
   async providers(signal?: AbortSignal): Promise<ApertureProvider[]> {
-    const [body, enabledModelIds] = await Promise.all([
+    const [body, enabledModelsById] = await Promise.all([
       this._fetch<{ providers?: unknown } | unknown[]>("/api/providers", {
         signal,
       }),
-      this.enabledModelIds(signal),
+      this.enabledModelsById(signal),
     ]);
 
     const parsed = parseProvidersBody(body);
-    if (enabledModelIds.size === 0) return parsed;
+    if (enabledModelsById.size === 0) return parsed;
 
     return parsed
-      .map((provider) => ({
-        ...provider,
-        models: provider.models.filter((id) => enabledModelIds.has(id)),
-      }))
+      .map((provider) => {
+        const models = provider.models.filter((id) =>
+          enabledModelsById.has(id),
+        );
+        const modelInfoById: Record<string, ApertureModelInfo> = {};
+        for (const id of models) {
+          const info = enabledModelsById.get(id);
+          if (info) modelInfoById[id] = info;
+        }
+        return { ...provider, models, modelInfoById };
+      })
       .filter((provider) => provider.models.length > 0);
   }
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -17,6 +17,51 @@ export const ProviderCompatibilitySchema = Type.Object(
 
 export type ProviderCompatibility = Static<typeof ProviderCompatibilitySchema>;
 
+/**
+ * Per-token USD pricing for a model, as reported by Aperture's `/v1/models`.
+ *
+ * All fields are per-token USD strings (e.g. `"0.00000100"`).
+ * `web_search` and `input_cache_write_1h` have no direct mapping in Pi's
+ * `ProviderModelConfig.cost` and are ignored when building model defaults.
+ */
+export interface ApertureModelPricing {
+  input?: string;
+  input_cache_read?: string;
+  input_cache_write?: string;
+  input_cache_write_1h?: string;
+  output?: string;
+  web_search?: string;
+}
+
+/**
+ * Model metadata retained from `/v1/models`. Used as a lookup so dedicated
+ * mode can attach pricing to model configs without re-fetching the gateway.
+ */
+export interface ApertureModelInfo {
+  id: string;
+  pricing?: ApertureModelPricing;
+}
+
+export const ApertureModelInfoSchema = Type.Object(
+  {
+    id: Type.String(),
+    pricing: Type.Optional(
+      Type.Object(
+        {
+          input: Type.Optional(Type.String()),
+          input_cache_read: Type.Optional(Type.String()),
+          input_cache_write: Type.Optional(Type.String()),
+          input_cache_write_1h: Type.Optional(Type.String()),
+          output: Type.Optional(Type.String()),
+          web_search: Type.Optional(Type.String()),
+        },
+        { additionalProperties: true },
+      ),
+    ),
+  },
+  { additionalProperties: true },
+);
+
 export const ApertureProviderSchema = Type.Object(
   {
     id: Type.String(),
@@ -24,6 +69,11 @@ export const ApertureProviderSchema = Type.Object(
     description: Type.String({ default: "" }),
     models: Type.Array(Type.String(), { default: [] }),
     compatibility: ProviderCompatibilitySchema,
+    // Populated from `/v1/models` so dedicated mode can attach pricing to
+    // model configs. Not present on the raw `/api/providers` response.
+    modelInfoById: Type.Optional(
+      Type.Record(Type.String(), ApertureModelInfoSchema),
+    ),
   },
   { additionalProperties: true },
 );


### PR DESCRIPTION
## Summary

Dedicated provider models were registered with zero costs because `/v1/models` was only used as an enabled-model filter; its `pricing` object was discarded.

This change retains each model's pricing from `/v1/models`, converts the per-token USD strings to per-million-token costs, and persists them to the dedicated models cache.

## Changes

- **src/api/types.ts** — added `ApertureModelPricing` and `ApertureModelInfo` types; optional `modelInfoById` on `ApertureProviderSchema`.
- **src/api/client.ts** — `enabledModelIds()` -> `enabledModelsById()` returning `Map<id, { pricing }>`; `providers()` attaches `modelInfoById` per provider alongside the existing model-id filtering.
- **extensions/aperture/dedicated/model-defaults.ts** — `ApertureModelDefaultsInput.pricing` now typed as `ApertureModelPricing`.
- **extensions/aperture/dedicated/runtime.ts** — `buildModels()` reads `provider.modelInfoById?.[modelId]?.pricing` and passes it into `buildDefaultModelConfig()`.
- Tests updated for the new field, with a pricing-retention test (client) and a cost-propagation test (runtime).

## Mapping

Aperture -> Pi `ProviderModelConfig.cost` (per-token USD -> per-million):

- `input` -> `input`
- `output` -> `output`
- `input_cache_read` -> `cacheRead`
- `input_cache_write` -> `cacheWrite`
- `web_search` and `input_cache_write_1h` ignored (no Pi cost field)

## Notes

- No cache migration needed; stale zero-cost entries self-heal on the next live sync, preserving the startup scoped-model benefit.
- `/v1/models` failure keeps the existing fallback (unfiltered providers, zero costs).

## Checklist

- typecheck: clean
- lint: clean
- tests: 58/58 pass
- schema: unchanged