### PR TITLE
fix(dedicated): route Bedrock through Aperture's /bedrock surface

### DIFF
--- a/extensions/aperture/dedicated/api-routing.test.ts
+++ b/extensions/aperture/dedicated/api-routing.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+import { getBaseUrlForApi } from "./api-routing";
+
+describe("getBaseUrlForApi", () => {
+  const gatewayUrl = "http://ai-gateway.tail692491.ts.net";
+  const baseUrl = `${gatewayUrl}/v1`;
+
+  test("routes bedrock-converse-stream through the /bedrock surface, not /v1", () => {
+    // Regression: falling through to the default branch here pointed
+    // bedrock_converse models at Aperture's OpenAI-shaped /v1 base and
+    // failed with a protocol error; Aperture's native Bedrock-compatible
+    // surface lives at /bedrock.
+    expect(
+      getBaseUrlForApi("bedrock-converse-stream", gatewayUrl, baseUrl),
+    ).toBe(`${gatewayUrl}/bedrock`);
+  });
+
+  test("keeps existing per-api base URL overrides", () => {
+    expect(getBaseUrlForApi("anthropic-messages", gatewayUrl, baseUrl)).toBe(
+      gatewayUrl,
+    );
+    expect(getBaseUrlForApi("google-generative-ai", gatewayUrl, baseUrl)).toBe(
+      `${gatewayUrl}/v1beta`,
+    );
+    expect(getBaseUrlForApi("google-vertex", gatewayUrl, baseUrl)).toBe(
+      `${gatewayUrl}/v1`,
+    );
+  });
+
+  test("falls back to the generic baseUrl for other apis (e.g. openai-responses)", () => {
+    expect(getBaseUrlForApi("openai-responses", gatewayUrl, baseUrl)).toBe(
+      baseUrl,
+    );
+    expect(getBaseUrlForApi("openai-completions", gatewayUrl, baseUrl)).toBe(
+      baseUrl,
+    );
+  });
+});

--- a/extensions/aperture/dedicated/api-routing.ts
+++ b/extensions/aperture/dedicated/api-routing.ts
@@ -35,6 +35,12 @@ export function getBaseUrlForApi(
       return `${gatewayUrl}/v1beta`;
     case "google-vertex":
       return `${gatewayUrl}/v1`;
+    // Aperture's native Bedrock-compatible surface lives at /bedrock, not
+    // /v1. The default branch below would otherwise point bedrock_converse
+    // models at the generic OpenAI-shaped base URL and fail with a
+    // protocol error.
+    case "bedrock-converse-stream":
+      return `${gatewayUrl}/bedrock`;
     default:
       // openai-completions / openai-responses: infer from the upstream base
       // URL (when known) whether the gateway root or gateway/v1 is correct.


### PR DESCRIPTION
Rebased and re-scoped onto current `main`. Per review feedback, this now
contains **only** the Bedrock base-URL fix — the no-auth OpenAI Responses
transport and the `getApiForCompatibility` priority-order change have been
dropped from this PR (the no-auth fix in particular relied on pi-ai's
internal APIs, which you flagged as a concern; that will be revisited
separately, ideally via the public `before_provider_headers` hook instead
of internal module access).

## Bug

`getBaseUrlForApi`'s default branch routes `bedrock-converse-stream`
models through `shouldUseGatewayRoot`, which only special-cases
`anthropic-messages` and `openai-codex-responses` for the gateway root,
and infers root-vs-`/v1` for `openai-completions`/`openai-responses` from
the upstream base URL. `bedrock-converse-stream` matches none of those,
so it falls through to the generic `gatewayUrl/v1` base — but Aperture's
native Bedrock-compatible surface lives at `gatewayUrl/bedrock`, not
`/v1`. Registering the OpenAI-shaped `/v1` base for Bedrock models fails
with a protocol error.

## Fix

Added an explicit `bedrock-converse-stream` case to `getBaseUrlForApi`
returning `${gatewayUrl}/bedrock`, mirroring the same fix already applied
on the proxy path.

## Verification

- Added a regression test (`extensions/aperture/dedicated/api-routing.test.ts`)
  covering the new case alongside the existing per-API base URL overrides.
- `pnpm test`, `pnpm typecheck`, `pnpm lint` all pass locally.
- Verified live against a real Aperture deployment: Claude Sonnet/Haiku
  (including tool calls) via Bedrock now work through the corrected
  `/bedrock` base URL. The `bedrock-converse` path additionally needs
  `AWS_BEDROCK_SKIP_AUTH=1` and `AWS_BEDROCK_FORCE_HTTP1=1` in the
  environment for pi-ai's built-in AWS SDK client (dummy credentials
  instead of real SigV4 signing; HTTP/1.1 since the SDK's default HTTP/2
  handler doesn't negotiate cleanly against this proxy) — an environment
  concern for users of this extension, not something it can set itself.
