### PR TITLE
feat(proxy): emit model selected event

### DIFF
--- a/.changeset/tidy-mice-notify.md
+++ b/.changeset/tidy-mice-notify.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-ts-aperture": patch
+---
+
+Emit an event when a selected model routes through an Aperture proxy provider.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,7 @@ There is no current `mode` setting. Legacy `mode` configs are migrated to capabi
 ### Proxy mode
 
 - Only overrides `baseUrl`, `apiKey`, and headers on existing providers. Model definitions are never touched.
+- Emits `aperture:proxy:model-selected` on session start and when a model from a configured proxy provider is selected. Dedicated `aperture` provider selections do not emit it.
 - Skips providers with no local models because there is nothing to reroute.
 - Provider selection maps Aperture providers to local Pi registry providers by id, exclusively from `/api/providers` cross-referenced with `/v1/models`, so only enabled providers (those whose models appear in `/v1/models`) are offered.
 - `anthropic-messages` and `openai-codex-responses` proxy registration use the Aperture root URL because Pi's Anthropic SDK and Codex adapter append their own API paths.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Reroutes existing Pi providers through Aperture. Each provider keeps its own mod
 
 Provider selection matches your local Pi providers against the providers enabled on the gateway. Optional per-provider verification warns when configured local models are missing from the gateway.
 
+When a selected model belongs to a proxied provider, the extension emits `aperture:proxy:model-selected` on Pi's event bus. The payload includes `model`, `selectionSource`, and `timestamp`. Dedicated `aperture` provider selections do not emit this event.
+
 ### Connectors
 
 [![Connectors walkthrough](https://assets.aliou.me/pi-extensions/demos/aperture/v0.8.0/connectors.gif)](https://assets.aliou.me/pi-extensions/demos/aperture/v0.8.0/connectors.mp4)

--- a/extensions/aperture/index.ts
+++ b/extensions/aperture/index.ts
@@ -6,9 +6,12 @@ import { configLoader } from "../../src/shared/config/loader";
 import {
   APERTURE_FEATURE_REGISTER_EVENT,
   APERTURE_FEATURE_REQUEST_EVENT,
+  APERTURE_PROXY_MODEL_SELECTED_EVENT,
   createFeatureRequestPayload,
+  createProxyModelSelectedPayload,
 } from "../../src/shared/events";
 import { emitConfigSync } from "../../src/shared/sync-bus";
+import { resolveProviderBaseUrl } from "../../src/url";
 import { DedicatedRuntime } from "./dedicated/runtime";
 import { registerOnboarding } from "./onboarding";
 import { ApertureRuntime } from "./proxy/runtime";
@@ -59,6 +62,26 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     knownModels = ctx.modelRegistry.getAll();
   };
 
+  const emitProxyModelSelected = (
+    model: { provider: string; id: string },
+    selectionSource: "set" | "cycle" | "restore" | "session_start",
+  ): void => {
+    const config = configLoader.getConfig();
+    const isProxied =
+      model.provider !== "aperture" &&
+      config.proxy.enabled &&
+      resolveProviderBaseUrl(config) !== null &&
+      config.proxy.upstreamProviders.some(
+        (provider) => provider.id === model.provider,
+      );
+    if (!isProxied) return;
+
+    pi.events.emit(
+      APERTURE_PROXY_MODEL_SELECTED_EVENT,
+      createProxyModelSelectedPayload(model, selectionSource),
+    );
+  };
+
   const onSync = (ctx: ExtensionContext): void => {
     updateKnownModels(ctx);
     emitConfigSync();
@@ -106,6 +129,11 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       createFeatureRequestPayload(),
     );
     onSync(ctx);
+    if (ctx.model) emitProxyModelSelected(ctx.model, "session_start");
+  });
+
+  pi.on("model_select", (event) => {
+    emitProxyModelSelected(event.model, event.source);
   });
 
   registerApertureSettings(pi, onSync, () => knownModels);

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -2,6 +2,8 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 export const APERTURE_FEATURE_REQUEST_EVENT = "aperture:feature:request";
 export const APERTURE_FEATURE_REGISTER_EVENT = "aperture:feature:register";
+export const APERTURE_PROXY_MODEL_SELECTED_EVENT =
+  "aperture:proxy:model-selected";
 
 export type ApertureFeatureId = "connectors";
 
@@ -15,6 +17,16 @@ export interface ApertureFeatureRegisterPayload {
   timestamp: string;
   feature: {
     id: ApertureFeatureId;
+  };
+}
+
+export interface ApertureProxyModelSelectedPayload {
+  source: "aperture";
+  timestamp: string;
+  selectionSource: "set" | "cycle" | "restore" | "session_start";
+  model: {
+    provider: string;
+    id: string;
   };
 }
 
@@ -36,6 +48,21 @@ export function createFeatureRegisterPayload(
     source: "aperture",
     timestamp: timestamp(),
     feature: { id: feature },
+  };
+}
+
+export function createProxyModelSelectedPayload(
+  model: { provider: string; id: string },
+  selectionSource: ApertureProxyModelSelectedPayload["selectionSource"],
+): ApertureProxyModelSelectedPayload {
+  return {
+    source: "aperture",
+    timestamp: timestamp(),
+    selectionSource,
+    model: {
+      provider: model.provider,
+      id: model.id,
+    },
   };
 }
 


### PR DESCRIPTION
> [!NOTE]
> Automated pull request by Pi

## Summary

- emit `aperture:proxy:model-selected` on session start and model selection
- limit emission to configured proxy providers with a valid gateway URL
- exclude the dedicated `aperture` provider

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`