### PR TITLE
fix(proxy): use version-segment rule for gateway base URL

### DIFF
--- a/.changeset/fix-proxy-base-url-rule.md
+++ b/.changeset/fix-proxy-base-url-rule.md
@@ -1,0 +1,11 @@
+---
+"@aliou/pi-ts-aperture": patch
+---
+
+Corrects the proxy-mode gateway-base-URL inference rule introduced in the previous release.
+
+The previous rule routed any upstream base URL that did not end in `/v1` to the gateway root, including root baseurls (Mistral, DeepSeek). Aperture has no `/chat/completions` route for those providers, so proxy requests to them 404'd.
+
+The corrected rule: a model uses the gateway root only when its upstream base URL ends in a version segment that is not `/v1` (e.g. Z.ai `/api/coding/paas/v4`), because Aperture would otherwise double the version (`/v4/v1/chat/completions`). Root baseurls and `/v1` baseurls (OpenAI, Groq, OpenRouter) keep `gateway/v1`, Aperture's standard `/v1/chat/completions` endpoint.
+
+The inference logic is extracted to `src/base-url-routing.ts` (`shouldUseGatewayRoot`) so dedicated mode can reuse it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ Pi-agnostic Aperture API and mapping code lives under `src/`. Extension glue (Pi
 - `api/client.ts` - Pi-agnostic Aperture API client for `/api/providers` and `/v1/models` (connectors via `/api/connectors`). `providers()` cross-references `/v1/models` so disabled providers — whose models never appear there — are filtered out, leaving only enabled, callable providers.
 - `api/types.ts` - Aperture API response types.
 - `provider-mapping.ts` - Maps Aperture providers to local Pi registry models for proxy and dedicated selection.
+- `base-url-routing.ts` - Shared gateway-root-vs-`gateway/v1` inference (`shouldUseGatewayRoot`) from the Pi API and the upstream provider base URL. Used by both proxy and dedicated modes.
 - `url.ts` - URL normalization helpers.
 - `mcp-client.ts` - MCP client for Aperture's `/v1/mcp` Streamable HTTP endpoint (2024-11-05 protocol).
 
@@ -143,7 +144,7 @@ There is no current `mode` setting. Legacy `mode` configs are migrated to capabi
 - Only overrides `baseUrl`, `apiKey`, and headers on existing providers. Model definitions are never touched.
 - Skips providers with no local models because there is nothing to reroute.
 - Provider selection maps Aperture providers to local Pi registry providers by id, exclusively from `/api/providers` cross-referenced with `/v1/models`, so only enabled providers (those whose models appear in `/v1/models`) are offered.
-- Proxy base URL is chosen per provider so Pi's SDK appends the same request path it would to the upstream. `anthropic-messages` and `openai-codex-responses` always use the Aperture root URL because Pi's Anthropic SDK and Codex adapter append their own API paths (`/v1/messages`, `/codex/responses`). For the OpenAI SDK APIs (`openai-completions` / `openai-responses`), the extension inspects the upstream model base URL captured at first registration: if its pathname ends in `/v1` (e.g. OpenAI `/v1`, Groq `/openai/v1`) it registers `gateway/v1`, otherwise (e.g. Z.ai `/api/coding/paas/v4`, DeepSeek root) it registers the gateway root. The upstream base URL is cached per provider so a settings reload (whose model list is already rewritten to the gateway) keeps the decision stable. Missing or unparseable URLs fall back to `gateway/v1`.
+- Proxy and dedicated modes share one gateway-base-URL rule, implemented in `src/base-url-routing.ts` (`shouldUseGatewayRoot`). `anthropic-messages` and `openai-codex-responses` always use the Aperture root URL because Pi's Anthropic SDK and Codex adapter append their own API paths (`/v1/messages`, `/codex/responses`). For the OpenAI SDK APIs (`openai-completions` / `openai-responses`), a model registers against the gateway root only when its upstream base URL ends in a version segment that is not `/v1` (e.g. Z.ai `/api/coding/paas/v4`), because Aperture would otherwise double the version (`/v4/v1/chat/completions`). Root baseurls (Mistral, DeepSeek) and `/v1` baseurls (OpenAI, Groq, OpenRouter) keep `gateway/v1`, which is Aperture's standard `/v1/chat/completions` endpoint. Missing or unparseable upstream URLs keep `gateway/v1`.
 - Optional per-provider gateway model verification (`shouldCheckGatewayModels`) warns if configured local models are missing from the Aperture gateway.
 - Removed proxy providers trigger unregistration.
 

--- a/extensions/aperture/proxy/runtime.test.ts
+++ b/extensions/aperture/proxy/runtime.test.ts
@@ -1,10 +1,11 @@
 import { readFileSync } from "node:fs";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ApertureClient } from "../../../src/api/client";
+import { shouldUseGatewayRoot } from "../../../src/base-url-routing";
 import { configLoader } from "../../../src/shared/config/loader";
 import type { ResolvedConfig } from "../../../src/shared/config/types";
 import type { Api, Model } from "../../../src/shared/types";
-import { ApertureRuntime, shouldUseGatewayRootForProxy } from "./runtime";
+import { ApertureRuntime } from "./runtime";
 
 vi.mock("../../../src/shared/config/loader", () => ({
   configLoader: {
@@ -79,9 +80,9 @@ describe("ApertureRuntime.sync", () => {
     expect(source).toMatch(
       /function resolveCodexUrl[\s\S]*if \(normalized\.endsWith\("\/codex\/responses"\)\)[\s\S]*return normalized;[\s\S]*if \(normalized\.endsWith\("\/codex"\)\)[\s\S]*return `\$\{normalized\}\/responses`;[\s\S]*return `\$\{normalized\}\/codex\/responses`;/,
     );
-    expect(shouldUseGatewayRootForProxy("openai-codex-responses")).toBe(true);
-    expect(shouldUseGatewayRootForProxy("anthropic-messages")).toBe(true);
-    expect(shouldUseGatewayRootForProxy("openai-responses")).toBe(false);
+    expect(shouldUseGatewayRoot("openai-codex-responses")).toBe(true);
+    expect(shouldUseGatewayRoot("anthropic-messages")).toBe(true);
+    expect(shouldUseGatewayRoot("openai-responses")).toBe(false);
   });
 
   test("uses gateway root for Anthropic and Codex because Pi appends API paths", async () => {
@@ -117,55 +118,56 @@ describe("ApertureRuntime.sync", () => {
   });
 });
 
-describe("shouldUseGatewayRootForProxy OpenAI SDK path inference", () => {
+describe("shouldUseGatewayRoot OpenAI SDK path inference", () => {
   test.each([
+    // /v1 baseurls keep gateway /v1 (OpenAI, Groq, OpenRouter, etc.).
     ["openai", "https://api.openai.com/v1", true, false],
     ["groq", "https://api.groq.com/openai/v1", true, false],
-    ["zai", "https://api.z.ai/api/coding/paas/v4", true, true],
-    ["deepseek", "https://api.deepseek.com", true, true],
-    ["fireworks", "https://api.fireworks.ai/inference", true, true],
-    ["v1beta", "https://example.test/v1beta", true, true],
-    ["path-after-v1", "https://example.test/v1/proxy", true, true],
+    ["openrouter", "https://openrouter.ai/api/v1", true, false],
     ["trailing-slash", "https://example.test/v1/", true, false],
+    // Root baseurls (Mistral, DeepSeek, Fireworks) keep gateway /v1: Aperture
+    // appends /v1/chat/completions to the root and the upstream serves it.
+    ["mistral", "https://api.mistral.ai", true, false],
+    ["deepseek", "https://api.deepseek.com", true, false],
+    ["fireworks", "https://api.fireworks.ai/inference", true, false],
+    // Non-/v1 version segments need the gateway root: Aperture would otherwise
+    // double the version (/v4/v1/chat/completions).
+    ["zai", "https://api.z.ai/api/coding/paas/v4", true, true],
+    ["zai-v4beta", "https://api.z.ai/api/coding/paas/v4beta", true, true],
+    ["v2", "https://example.test/v2", true, true],
+    ["v10", "https://example.test/v10", true, true],
+    // Non-version path segments are not treated as versions.
+    ["non-version", "https://example.test/inference", true, false],
+    ["vision", "https://example.test/vision", true, false],
+    // openai-responses follows the same rule.
     ["responses-openai", "https://api.openai.com/v1", false, false],
     ["responses-zai", "https://api.z.ai/api/coding/paas/v4", false, true],
   ])("%s completions baseUrl %s", (_name, baseUrl, isCompletions, expectedRoot) => {
     const api: Api = isCompletions ? "openai-completions" : "openai-responses";
-    expect(shouldUseGatewayRootForProxy(api, baseUrl)).toBe(expectedRoot);
+    expect(shouldUseGatewayRoot(api, baseUrl)).toBe(expectedRoot);
   });
 
   test("missing upstream base URL keeps /v1 for OpenAI SDK APIs", () => {
-    expect(shouldUseGatewayRootForProxy("openai-completions")).toBe(false);
-    expect(shouldUseGatewayRootForProxy("openai-responses")).toBe(false);
+    expect(shouldUseGatewayRoot("openai-completions")).toBe(false);
+    expect(shouldUseGatewayRoot("openai-responses")).toBe(false);
   });
 
   test("unparseable base URL keeps /v1 for OpenAI SDK APIs", () => {
-    expect(
-      shouldUseGatewayRootForProxy("openai-completions", "not a url"),
-    ).toBe(false);
+    expect(shouldUseGatewayRoot("openai-completions", "not a url")).toBe(false);
   });
 
   test("non-OpenAI-SDK APIs keep /v1 regardless of base URL", () => {
     expect(
-      shouldUseGatewayRootForProxy(
-        "google-generative-ai",
-        "https://example.test/v4",
-      ),
+      shouldUseGatewayRoot("google-generative-ai", "https://example.test/v4"),
     ).toBe(false);
   });
 
   test("Anthropic and Codex always use root regardless of base URL", () => {
     expect(
-      shouldUseGatewayRootForProxy(
-        "anthropic-messages",
-        "https://example.test/v1",
-      ),
+      shouldUseGatewayRoot("anthropic-messages", "https://example.test/v1"),
     ).toBe(true);
     expect(
-      shouldUseGatewayRootForProxy(
-        "openai-codex-responses",
-        "https://example.test/v1",
-      ),
+      shouldUseGatewayRoot("openai-codex-responses", "https://example.test/v1"),
     ).toBe(true);
   });
 });

--- a/extensions/aperture/proxy/runtime.ts
+++ b/extensions/aperture/proxy/runtime.ts
@@ -1,5 +1,6 @@
 import { ApertureClient } from "../../../src/api/client";
 import type { ApertureProvider } from "../../../src/api/types";
+import { shouldUseGatewayRoot } from "../../../src/base-url-routing";
 import { configLoader } from "../../../src/shared/config/loader";
 import type { ResolvedConfig } from "../../../src/shared/config/types";
 import type {
@@ -11,54 +12,6 @@ import type {
 import { resolveGatewayUrl, resolveProviderBaseUrl } from "../../../src/url";
 
 const MAX_MISSING_MODELS_PER_PROVIDER = 5;
-
-const ROOT_BASE_URL_APIS = new Set<Api>([
-  // Pi's Anthropic adapter uses Anthropic's SDK, which appends /v1/messages
-  // itself. Registering /v1 would produce /v1/v1/messages, which Aperture
-  // does not expose.
-  "anthropic-messages",
-  // Pi's Codex adapter appends /codex/responses itself. Registering /v1
-  // would produce /v1/codex/responses, which Aperture does not expose.
-  "openai-codex-responses",
-]);
-
-// Pi passes `model.baseUrl` straight to the OpenAI SDK for these APIs, which
-// then appends /chat/completions or /responses. The terminal /v1 segment of
-// the upstream provider base URL is therefore part of its API shape: OpenAI
-// (/v1) and Groq (/openai/v1) need gateway /v1, while Z.ai
-// (/api/coding/paas/v4) needs the gateway root.
-const OPENAI_SDK_APIS = new Set<Api>([
-  "openai-completions",
-  "openai-responses",
-]);
-
-/**
- * `true` when `baseUrl`'s pathname ends in `/v1`, `false` when it does not,
- * `undefined` when the URL is missing or cannot be parsed (caller falls back
- * to a conservative default).
- */
-function hasTerminalV1Path(baseUrl: string | undefined): boolean | undefined {
-  if (!baseUrl) return undefined;
-  try {
-    const path = new URL(baseUrl).pathname.replace(/\/+$/u, "");
-    return path.endsWith("/v1");
-  } catch {
-    return undefined;
-  }
-}
-
-export function shouldUseGatewayRootForProxy(
-  api: Api,
-  upstreamBaseUrl?: string,
-): boolean {
-  if (ROOT_BASE_URL_APIS.has(api)) return true;
-  // Non-OpenAI-SDK APIs (Gemini, Bedrock, ...) build request paths their own
-  // way; keep the conservative gateway /v1 behavior.
-  if (!OPENAI_SDK_APIS.has(api)) return false;
-  // Use the gateway root only when we know the upstream does not end in /v1.
-  // Missing or unparseable URLs keep /v1 to stay safe.
-  return hasTerminalV1Path(upstreamBaseUrl) === false;
-}
 
 export class ApertureRuntime {
   // Upstream provider base URLs captured on first registration. A settings
@@ -104,7 +57,7 @@ export class ApertureRuntime {
         this.upstreamBaseUrls.set(providerName, upstreamBaseUrl);
       }
 
-      const providerBaseUrl = shouldUseGatewayRootForProxy(api, upstreamBaseUrl)
+      const providerBaseUrl = shouldUseGatewayRoot(api, upstreamBaseUrl)
         ? gatewayRoot
         : baseUrl;
 

--- a/src/base-url-routing.ts
+++ b/src/base-url-routing.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared base-URL routing logic for proxy and dedicated modes.
+ *
+ * Pi-agnostic: decides whether a model should be registered against the
+ * Aperture gateway root or `gateway/v1`, based on the Pi API and the upstream
+ * provider's base URL.
+ *
+ * Both modes share the same rule because Aperture's URL construction is the
+ * same in both: it appends the incoming request path to the provider's
+ * `baseurl`. A standard client sends `/v1/chat/completions`, which works for
+ * providers whose upstream is a root (Mistral, DeepSeek) or ends in `/v1`
+ * (OpenAI, Groq, OpenRouter). It breaks only for providers whose `baseurl`
+ * already includes a non-`/v1` version segment (e.g. Z.ai
+ * `/api/coding/paas/v4`), because `/v1` doubles on top (`/v4/v1/...`). Those
+ * providers need the gateway root so the client sends a versionless path.
+ */
+
+import type { Api } from "@earendil-works/pi-ai";
+
+const ROOT_BASE_URL_APIS = new Set<Api>([
+  // Pi's Anthropic adapter uses Anthropic's SDK, which appends /v1/messages
+  // itself. Registering /v1 would produce /v1/v1/messages, which Aperture
+  // does not expose.
+  "anthropic-messages",
+  // Pi's Codex adapter appends /codex/responses itself. Registering /v1
+  // would produce /v1/codex/responses, which Aperture does not expose.
+  "openai-codex-responses",
+]);
+
+// Pi passes `model.baseUrl` straight to the OpenAI SDK for these APIs, which
+// then appends /chat/completions or /responses.
+const OPENAI_SDK_APIS = new Set<Api>([
+  "openai-completions",
+  "openai-responses",
+]);
+
+/**
+ * `true` when `baseUrl`'s pathname ends in a version segment that is NOT `/v1`
+ * (e.g. `/v4`, `/v4beta`, `/v2rc1`). Such providers need a versionless client
+ * path because Aperture would otherwise double the version (`/v4/v1/...`).
+ * Returns `false` for `/v1`, root baseurls, and missing/unparseable URLs.
+ */
+function hasNonV1VersionPath(baseUrl: string | undefined): boolean {
+  if (!baseUrl) return false;
+  try {
+    const path = new URL(baseUrl).pathname.replace(/\/+$/u, "");
+    const match = path.match(/\/(v\d+\w*)$/u);
+    return match !== null && match[1] !== "v1";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether a model should register against the Aperture gateway root instead of
+ * `gateway/v1`.
+ *
+ * - Anthropic and Codex always use the root (their SDKs/adapter append the full
+ *   API path themselves).
+ * - OpenAI SDK APIs (`openai-completions`, `openai-responses`) use the root
+ *   only when the upstream base URL ends in a non-`/v1` version segment
+ *   (e.g. Z.ai `/api/coding/paas/v4`).
+ * - Other APIs keep the conservative `gateway/v1` behavior.
+ * - Missing or unparseable upstream URLs keep `gateway/v1` to stay safe.
+ */
+export function shouldUseGatewayRoot(
+  api: Api,
+  upstreamBaseUrl?: string,
+): boolean {
+  if (ROOT_BASE_URL_APIS.has(api)) return true;
+  if (!OPENAI_SDK_APIS.has(api)) return false;
+  return hasNonV1VersionPath(upstreamBaseUrl);
+}


### PR DESCRIPTION
> [!NOTE]
> This PR was authored by Pi (the coding agent), driven by `zai/glm-5.2`. Review the diff before merging.

## Summary

Corrects the proxy-mode gateway-base-URL inference rule shipped in the previous release (`4ee9b0a`).

## The bug

The previous rule routed any upstream base URL that did **not** end in `/v1` to the gateway root. That included **root baseurls** (Mistral, DeepSeek), but Aperture has no `/chat/completions` route for those providers, so proxy requests to them 404'd.

Verified against the live gateway (`ai.tetra-albacore.ts.net`):

| Provider | `/v1/chat/completions` | `/chat/completions` (root) |
| --- | --- | --- |
| Z.ai (`glm-5.2`) | **404** (`/v4/v1/...`) | 200 |
| Mistral | 200 | **404** (no route) |

## The fix

A model uses the gateway root only when its upstream base URL ends in a version segment that is **not** `/v1` (e.g. Z.ai `/api/coding/paas/v4`), because Aperture would otherwise double the version (`/v4/v1/chat/completions`). Root baseurls and `/v1` baseurls (OpenAI, Groq, OpenRouter) keep `gateway/v1`, Aperture's standard `/v1/chat/completions` endpoint.

The inference is extracted to `src/base-url-routing.ts` (`shouldUseGatewayRoot`) so dedicated mode can reuse it (separate PR).

## Checks

- `pnpm typecheck`, `pnpm lint`, `pnpm test` (80 tests), `pnpm check:schema` all pass
